### PR TITLE
fix: リプライ公開範囲の自動制限が非公開投稿で機能しないバグ修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
+        run: npm ci
 
       - name: Run unit tests
         working-directory: frontend

--- a/frontend/src/components/notes/NoteComposer.tsx
+++ b/frontend/src/components/notes/NoteComposer.tsx
@@ -21,6 +21,12 @@ import {
   type Visibility,
 } from "@nekonoverse/ui/stores/composer";
 
+/** APIレスポンスの "private" を内部表現 "followers" に正規化する */
+function normalizeVisibility(v: string): Visibility {
+  if (v === "private") return "followers";
+  return v as Visibility;
+}
+
 const VISIBILITY_OPTIONS: { key: Visibility; emoji: string; i18nKey: string }[] = [
   { key: "public", emoji: "\u{1F310}", i18nKey: "visibility.public" },
   { key: "unlisted", emoji: "\u{1F513}", i18nKey: "visibility.unlisted" },
@@ -95,7 +101,7 @@ export default function NoteComposer(props: Props) {
   createEffect(() => {
     const targetNote = props.replyTo || props.quoteNote;
     if (targetNote) {
-      const parentVis = targetNote.visibility as Visibility;
+      const parentVis = normalizeVisibility(targetNote.visibility);
       if (VISIBILITY_OPTIONS.some((o) => o.key === parentVis)) {
         setParentVisibility(parentVis);
         const userVis = getInitialVisibility();
@@ -130,7 +136,7 @@ export default function NoteComposer(props: Props) {
       } else {
         const targetNote = props.replyTo || props.quoteNote;
         if (targetNote) {
-          const parentVis = targetNote.visibility as Visibility;
+          const parentVis = normalizeVisibility(targetNote.visibility);
           if (VISIBILITY_OPTIONS.some((o) => o.key === parentVis)) {
             setParentVisibility(parentVis);
             setVisibility(moreRestrictiveVisibility(getInitialVisibility(), parentVis));

--- a/tests/e2e/tests/helpers.ts
+++ b/tests/e2e/tests/helpers.ts
@@ -133,9 +133,9 @@ function crc32(buf: Buffer): number {
  * Create a note via the API. Requires an authenticated page (call loginAsAdmin first).
  * Returns the created note's JSON response.
  */
-export async function createNote(page: Page, text: string) {
+export async function createNote(page: Page, text: string, visibility = "public") {
   const resp = await page.request.post("/api/v1/statuses", {
-    data: { content: text, visibility: "public" },
+    data: { content: text, visibility },
   });
   expect(resp.status()).toBe(201);
   return resp.json();

--- a/tests/e2e/tests/reply-visibility.spec.ts
+++ b/tests/e2e/tests/reply-visibility.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "@playwright/test";
+import { loginAsAdmin, createNote } from "./helpers";
+
+test.describe("Reply Visibility", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test("reply to followers-only note defaults to followers", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `fonly-vis-${uid}`, "followers");
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    // コンポーザーの公開範囲アイコンがロック (followers) であること
+    const visIcon = page.locator(".thread-reply-composer .composer-vis-icon");
+    await expect(visIcon).toBeVisible({ timeout: 5_000 });
+    await expect(visIcon).toHaveText("\u{1F512}");
+  });
+
+  test("warning appears when widening reply visibility", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `warn-vis-${uid}`, "followers");
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    const composer = page.locator(".thread-reply-composer");
+
+    // 初期状態では警告なし
+    await expect(composer.locator(".composer-visibility-warning")).not.toBeVisible();
+
+    // 公開範囲ドロップダウンを開いて public を選択
+    await composer.locator(".composer-vis-toggle").click();
+    await composer.locator(".composer-vis-item").first().click();
+
+    // 警告バナーが表示されること
+    await expect(composer.locator(".composer-visibility-warning")).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("reply to unlisted note defaults to unlisted", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `unlisted-vis-${uid}`, "unlisted");
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    const visIcon = page.locator(".thread-reply-composer .composer-vis-icon");
+    await expect(visIcon).toBeVisible({ timeout: 5_000 });
+    await expect(visIcon).toHaveText("\u{1F513}");
+  });
+
+  test("reply to public note stays public with no warning", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `public-vis-${uid}`);
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    const composer = page.locator(".thread-reply-composer");
+    const visIcon = composer.locator(".composer-vis-icon");
+    await expect(visIcon).toBeVisible({ timeout: 5_000 });
+    await expect(visIcon).toHaveText("\u{1F310}");
+
+    // 警告なし
+    await expect(composer.locator(".composer-visibility-warning")).not.toBeVisible();
+  });
+
+  test("reply to direct note defaults to direct", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `direct-vis-${uid}`, "direct");
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    const visIcon = page.locator(".thread-reply-composer .composer-vis-icon");
+    await expect(visIcon).toBeVisible({ timeout: 5_000 });
+    await expect(visIcon).toHaveText("\u2709\uFE0F");
+  });
+
+  test("reply via modal inherits followers visibility", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `modal-vis-${uid}`, "followers");
+
+    // ホームタイムラインで自分の followers-only ノートを見つけてリプライ
+    await page.goto("/?tl=home");
+    await page.waitForSelector(".note-card", { timeout: 10_000 });
+
+    const noteCard = page
+      .locator(".note-card")
+      .filter({ hasText: `modal-vis-${uid}` })
+      .first();
+    await noteCard.locator(".note-reply-btn").click();
+
+    // モーダルが開く
+    await expect(page.locator(".compose-modal-content")).toBeVisible({ timeout: 5_000 });
+
+    // 公開範囲がロック (followers) であること
+    const visIcon = page.locator(".compose-modal-content .composer-vis-icon");
+    await expect(visIcon).toHaveText("\u{1F512}");
+  });
+});


### PR DESCRIPTION
## Summary
- 非公開（followers-only）投稿へのリプライで公開範囲が自動制限されず、警告も出ないバグを修正
- APIレスポンスの `"private"` を内部表現 `"followers"` に正規化する `normalizeVisibility()` を追加
- リプライ公開範囲のE2Eテスト6ケース新規追加

## 原因
Mastodon互換APIが `followers` → `"private"` を返すが、`VISIBILITY_OPTIONS` は `"followers"` のみ → `parentVisibility` が設定されない

## Test plan
- [ ] E2E: followers-only投稿へのリプライがfollowers継承
- [ ] E2E: 公開範囲拡大時に警告表示
- [ ] E2E: unlisted/public/direct各パターンの継承
- [ ] E2E: モーダル経由のリプライでも継承

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
