### PR TITLE
test: リプライ公開範囲のテストカバレッジ強化

### DIFF
--- a/backend/tests/test_api_statuses.py
+++ b/backend/tests/test_api_statuses.py
@@ -887,6 +887,56 @@ async def test_reply_visibility_enforcement(authed_client, mock_valkey):
         )
 
 
+async def test_reply_visibility_cross_user(
+    authed_client, test_user_b, app_client, mock_valkey,
+):
+    """他ユーザーの非公開投稿へのリプライも公開範囲がクランプされる。"""
+    # User A が unlisted ノートを作成
+    parent = await authed_client.post("/api/v1/statuses", json={
+        "content": "Unlisted parent", "visibility": "unlisted",
+    })
+    parent_id = parent.json()["id"]
+
+    # User B に切り替え
+    from unittest.mock import AsyncMock
+    mock_valkey.get = AsyncMock(return_value=str(test_user_b.id))
+    app_client.cookies.set("nekonoverse_session", "session-b")
+
+    # User B が public でリプライ → unlisted にクランプ
+    reply = await app_client.post("/api/v1/statuses", json={
+        "content": "Cross-user reply", "visibility": "public",
+        "in_reply_to_id": parent_id,
+    })
+    assert reply.status_code == 201
+    assert reply.json()["visibility"] == "unlisted"
+
+
+async def test_reply_visibility_private_alias(authed_client, mock_valkey):
+    """API入力で "private" を使ったリプライも正しくクランプされる。"""
+    # "private" エイリアスで followers-only 親ノートを作成
+    parent = await authed_client.post("/api/v1/statuses", json={
+        "content": "Private alias parent", "visibility": "private",
+    })
+    assert parent.status_code == 201
+    assert parent.json()["visibility"] == "private"  # API応答は "private"
+
+    # "private" エイリアスで同等のリプライ → そのまま通る
+    reply = await authed_client.post("/api/v1/statuses", json={
+        "content": "Private alias reply", "visibility": "private",
+        "in_reply_to_id": parent.json()["id"],
+    })
+    assert reply.status_code == 201
+    assert reply.json()["visibility"] == "private"
+
+    # public でリプライ → followers (private) にクランプ
+    wider = await authed_client.post("/api/v1/statuses", json={
+        "content": "Public reply to private parent", "visibility": "public",
+        "in_reply_to_id": parent.json()["id"],
+    })
+    assert wider.status_code == 201
+    assert wider.json()["visibility"] == "private"
+
+
 async def test_pin_status(authed_client, mock_valkey):
     create_resp = await authed_client.post("/api/v1/statuses", json={
         "content": "Pin me", "visibility": "public"

--- a/frontend/src/components/notes/NoteComposer.tsx
+++ b/frontend/src/components/notes/NoteComposer.tsx
@@ -17,15 +17,10 @@ import {
   defaultVisibility,
   setLastVisibility,
   moreRestrictiveVisibility,
+  normalizeVisibility,
   VISIBILITY_RANK,
   type Visibility,
 } from "@nekonoverse/ui/stores/composer";
-
-/** APIレスポンスの "private" を内部表現 "followers" に正規化する */
-function normalizeVisibility(v: string): Visibility {
-  if (v === "private") return "followers";
-  return v as Visibility;
-}
 
 const VISIBILITY_OPTIONS: { key: Visibility; emoji: string; i18nKey: string }[] = [
   { key: "public", emoji: "\u{1F310}", i18nKey: "visibility.public" },

--- a/packages/ui/src/stores/composer.test.ts
+++ b/packages/ui/src/stores/composer.test.ts
@@ -1,4 +1,64 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  moreRestrictiveVisibility,
+  normalizeVisibility,
+  VISIBILITY_RANK,
+  type Visibility,
+} from "./composer";
+
+describe("VISIBILITY_RANK", () => {
+  it("public < unlisted < followers < direct の順に制限が強い", () => {
+    expect(VISIBILITY_RANK.public).toBeLessThan(VISIBILITY_RANK.unlisted);
+    expect(VISIBILITY_RANK.unlisted).toBeLessThan(VISIBILITY_RANK.followers);
+    expect(VISIBILITY_RANK.followers).toBeLessThan(VISIBILITY_RANK.direct);
+  });
+});
+
+describe("normalizeVisibility", () => {
+  it('"private" を "followers" に正規化する', () => {
+    expect(normalizeVisibility("private")).toBe("followers");
+  });
+
+  it.each(["public", "unlisted", "followers", "direct"] as const)(
+    '"%s" はそのまま返す',
+    (v) => {
+      expect(normalizeVisibility(v)).toBe(v);
+    },
+  );
+});
+
+describe("moreRestrictiveVisibility", () => {
+  const cases: [Visibility, Visibility, Visibility][] = [
+    // 同じ同士
+    ["public", "public", "public"],
+    ["unlisted", "unlisted", "unlisted"],
+    ["followers", "followers", "followers"],
+    ["direct", "direct", "direct"],
+    // public と他
+    ["public", "unlisted", "unlisted"],
+    ["public", "followers", "followers"],
+    ["public", "direct", "direct"],
+    // unlisted と他
+    ["unlisted", "public", "unlisted"],
+    ["unlisted", "followers", "followers"],
+    ["unlisted", "direct", "direct"],
+    // followers と他
+    ["followers", "public", "followers"],
+    ["followers", "unlisted", "followers"],
+    ["followers", "direct", "direct"],
+    // direct と他
+    ["direct", "public", "direct"],
+    ["direct", "unlisted", "direct"],
+    ["direct", "followers", "direct"],
+  ];
+
+  it.each(cases)(
+    "moreRestrictiveVisibility(%s, %s) === %s",
+    (a, b, expected) => {
+      expect(moreRestrictiveVisibility(a, b)).toBe(expected);
+    },
+  );
+});
 
 describe("composer store", () => {
   beforeEach(() => {

--- a/packages/ui/src/stores/composer.ts
+++ b/packages/ui/src/stores/composer.ts
@@ -63,6 +63,12 @@ export function moreRestrictiveVisibility(a: Visibility, b: Visibility): Visibil
   return (VISIBILITY_RANK[a] ?? 0) >= (VISIBILITY_RANK[b] ?? 0) ? a : b;
 }
 
+/** APIレスポンスの "private" を内部表現 "followers" に正規化する。 */
+export function normalizeVisibility(v: string): Visibility {
+  if (v === "private") return "followers";
+  return v as Visibility;
+}
+
 // --- 下書きストレージ ---
 
 export interface Draft {


### PR DESCRIPTION
## Summary
- `normalizeVisibility` を NoteComposer のローカル関数 → composer store のエクスポート関数に移動
- `moreRestrictiveVisibility` の全16組合せユニットテスト追加
- `normalizeVisibility` のユニットテスト追加（"private"→"followers" 変換）
- `VISIBILITY_RANK` の順序検証テスト追加
- バックエンド: "private" エイリアスでのリプライ投稿テスト追加
- バックエンド: クロスユーザーリプライ公開範囲クランプのテスト追加

## Test plan
- [ ] vitest: composer.test.ts の新規テスト全パス
- [ ] pytest: test_reply_visibility_private_alias パス
- [ ] pytest: test_reply_visibility_cross_user パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
