### PR TITLE
chore: vite セキュリティアップデート (CVE-2026-39363)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260329-3",
+  "version": "20260402-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260329-3",
+      "version": "20260402-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",
@@ -22,7 +22,7 @@
         "@types/qrcode": "^1.5.6",
         "jsdom": "^28.1.0",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0",
+        "vite": "^6.4.2",
         "vite-plugin-pwa": "^0.21.0",
         "vite-plugin-solid": "^2.11.0",
         "vitest": "^4.0.18"
@@ -6830,7 +6830,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@types/qrcode": "^1.5.6",
     "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0",
+    "vite": "^6.4.2",
     "vite-plugin-pwa": "^0.21.0",
     "vite-plugin-solid": "^2.11.0",
     "vitest": "^4.0.18"


### PR DESCRIPTION
## Summary
- vite 6.4.1 → 6.4.2 (CVE-2026-39363, High)
- Dev Server WebSocket経由の任意ファイル読み取り脆弱性の修正

## Test plan
- [ ] frontend-build パス
- [ ] E2Eテスト パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
