### PR TITLE
Release 20260407-1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: frontend
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
+        run: npm ci
 
       - name: Run unit tests
         working-directory: frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [20260407-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260407-1) — 2026-04-07
+
+### セキュリティ
+
+- **依存関係のセキュリティアップデート** — vite 6.4.2 (CVE-2026-39363, Dev Server WebSocket経由の任意ファイル読み取り)
+
+### 修正
+
+- **リプライ公開範囲の自動制限バグ修正** — 非公開(followers-only)投稿にリプライする際、公開範囲が自動制限されず警告も表示されない問題を修正。APIの "private" を内部表現 "followers" に正規化 (#961)
+- **CI frontend-build 修正** — npm ci を使用しlockfileを尊重するよう変更
+
+### テスト
+
+- **リプライ公開範囲のテストカバレッジ強化** — E2E 6ケース、フロントエンドユニットテスト(normalizeVisibility, moreRestrictiveVisibility全16組合せ)、バックエンドテスト追加 (#962)
+
+---
+
 ## [20260402-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260402-1) — 2026-04-02
 
 ### セキュリティ

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260402-1"
+__version__ = "20260407-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260402-1"
+version = "20260407-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_api_statuses.py
+++ b/backend/tests/test_api_statuses.py
@@ -887,6 +887,56 @@ async def test_reply_visibility_enforcement(authed_client, mock_valkey):
         )
 
 
+async def test_reply_visibility_cross_user(
+    authed_client, test_user_b, app_client, mock_valkey,
+):
+    """他ユーザーの非公開投稿へのリプライも公開範囲がクランプされる。"""
+    # User A が unlisted ノートを作成
+    parent = await authed_client.post("/api/v1/statuses", json={
+        "content": "Unlisted parent", "visibility": "unlisted",
+    })
+    parent_id = parent.json()["id"]
+
+    # User B に切り替え
+    from unittest.mock import AsyncMock
+    mock_valkey.get = AsyncMock(return_value=str(test_user_b.id))
+    app_client.cookies.set("nekonoverse_session", "session-b")
+
+    # User B が public でリプライ → unlisted にクランプ
+    reply = await app_client.post("/api/v1/statuses", json={
+        "content": "Cross-user reply", "visibility": "public",
+        "in_reply_to_id": parent_id,
+    })
+    assert reply.status_code == 201
+    assert reply.json()["visibility"] == "unlisted"
+
+
+async def test_reply_visibility_private_alias(authed_client, mock_valkey):
+    """API入力で "private" を使ったリプライも正しくクランプされる。"""
+    # "private" エイリアスで followers-only 親ノートを作成
+    parent = await authed_client.post("/api/v1/statuses", json={
+        "content": "Private alias parent", "visibility": "private",
+    })
+    assert parent.status_code == 201
+    assert parent.json()["visibility"] == "private"  # API応答は "private"
+
+    # "private" エイリアスで同等のリプライ → そのまま通る
+    reply = await authed_client.post("/api/v1/statuses", json={
+        "content": "Private alias reply", "visibility": "private",
+        "in_reply_to_id": parent.json()["id"],
+    })
+    assert reply.status_code == 201
+    assert reply.json()["visibility"] == "private"
+
+    # public でリプライ → followers (private) にクランプ
+    wider = await authed_client.post("/api/v1/statuses", json={
+        "content": "Public reply to private parent", "visibility": "public",
+        "in_reply_to_id": parent.json()["id"],
+    })
+    assert wider.status_code == 201
+    assert wider.json()["visibility"] == "private"
+
+
 async def test_pin_status(authed_client, mock_valkey):
     create_resp = await authed_client.post("/api/v1/statuses", json={
         "content": "Pin me", "visibility": "public"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260329-3",
+  "version": "20260402-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260329-3",
+      "version": "20260402-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",
@@ -22,7 +22,7 @@
         "@types/qrcode": "^1.5.6",
         "jsdom": "^28.1.0",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0",
+        "vite": "^6.4.2",
         "vite-plugin-pwa": "^0.21.0",
         "vite-plugin-solid": "^2.11.0",
         "vitest": "^4.0.18"
@@ -6830,7 +6830,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@types/qrcode": "^1.5.6",
     "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0",
+    "vite": "^6.4.2",
     "vite-plugin-pwa": "^0.21.0",
     "vite-plugin-solid": "^2.11.0",
     "vitest": "^4.0.18"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260402-1",
+  "version": "20260407-1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/components/notes/NoteComposer.tsx
+++ b/frontend/src/components/notes/NoteComposer.tsx
@@ -17,15 +17,10 @@ import {
   defaultVisibility,
   setLastVisibility,
   moreRestrictiveVisibility,
+  normalizeVisibility,
   VISIBILITY_RANK,
   type Visibility,
 } from "@nekonoverse/ui/stores/composer";
-
-/** APIレスポンスの "private" を内部表現 "followers" に正規化する */
-function normalizeVisibility(v: string): Visibility {
-  if (v === "private") return "followers";
-  return v as Visibility;
-}
 
 const VISIBILITY_OPTIONS: { key: Visibility; emoji: string; i18nKey: string }[] = [
   { key: "public", emoji: "\u{1F310}", i18nKey: "visibility.public" },

--- a/frontend/src/components/notes/NoteComposer.tsx
+++ b/frontend/src/components/notes/NoteComposer.tsx
@@ -21,6 +21,12 @@ import {
   type Visibility,
 } from "@nekonoverse/ui/stores/composer";
 
+/** APIレスポンスの "private" を内部表現 "followers" に正規化する */
+function normalizeVisibility(v: string): Visibility {
+  if (v === "private") return "followers";
+  return v as Visibility;
+}
+
 const VISIBILITY_OPTIONS: { key: Visibility; emoji: string; i18nKey: string }[] = [
   { key: "public", emoji: "\u{1F310}", i18nKey: "visibility.public" },
   { key: "unlisted", emoji: "\u{1F513}", i18nKey: "visibility.unlisted" },
@@ -95,7 +101,7 @@ export default function NoteComposer(props: Props) {
   createEffect(() => {
     const targetNote = props.replyTo || props.quoteNote;
     if (targetNote) {
-      const parentVis = targetNote.visibility as Visibility;
+      const parentVis = normalizeVisibility(targetNote.visibility);
       if (VISIBILITY_OPTIONS.some((o) => o.key === parentVis)) {
         setParentVisibility(parentVis);
         const userVis = getInitialVisibility();
@@ -130,7 +136,7 @@ export default function NoteComposer(props: Props) {
       } else {
         const targetNote = props.replyTo || props.quoteNote;
         if (targetNote) {
-          const parentVis = targetNote.visibility as Visibility;
+          const parentVis = normalizeVisibility(targetNote.visibility);
           if (VISIBILITY_OPTIONS.some((o) => o.key === parentVis)) {
             setParentVisibility(parentVis);
             setVisibility(moreRestrictiveVisibility(getInitialVisibility(), parentVis));

--- a/packages/ui/src/stores/composer.test.ts
+++ b/packages/ui/src/stores/composer.test.ts
@@ -1,4 +1,64 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  moreRestrictiveVisibility,
+  normalizeVisibility,
+  VISIBILITY_RANK,
+  type Visibility,
+} from "./composer";
+
+describe("VISIBILITY_RANK", () => {
+  it("public < unlisted < followers < direct の順に制限が強い", () => {
+    expect(VISIBILITY_RANK.public).toBeLessThan(VISIBILITY_RANK.unlisted);
+    expect(VISIBILITY_RANK.unlisted).toBeLessThan(VISIBILITY_RANK.followers);
+    expect(VISIBILITY_RANK.followers).toBeLessThan(VISIBILITY_RANK.direct);
+  });
+});
+
+describe("normalizeVisibility", () => {
+  it('"private" を "followers" に正規化する', () => {
+    expect(normalizeVisibility("private")).toBe("followers");
+  });
+
+  it.each(["public", "unlisted", "followers", "direct"] as const)(
+    '"%s" はそのまま返す',
+    (v) => {
+      expect(normalizeVisibility(v)).toBe(v);
+    },
+  );
+});
+
+describe("moreRestrictiveVisibility", () => {
+  const cases: [Visibility, Visibility, Visibility][] = [
+    // 同じ同士
+    ["public", "public", "public"],
+    ["unlisted", "unlisted", "unlisted"],
+    ["followers", "followers", "followers"],
+    ["direct", "direct", "direct"],
+    // public と他
+    ["public", "unlisted", "unlisted"],
+    ["public", "followers", "followers"],
+    ["public", "direct", "direct"],
+    // unlisted と他
+    ["unlisted", "public", "unlisted"],
+    ["unlisted", "followers", "followers"],
+    ["unlisted", "direct", "direct"],
+    // followers と他
+    ["followers", "public", "followers"],
+    ["followers", "unlisted", "followers"],
+    ["followers", "direct", "direct"],
+    // direct と他
+    ["direct", "public", "direct"],
+    ["direct", "unlisted", "direct"],
+    ["direct", "followers", "direct"],
+  ];
+
+  it.each(cases)(
+    "moreRestrictiveVisibility(%s, %s) === %s",
+    (a, b, expected) => {
+      expect(moreRestrictiveVisibility(a, b)).toBe(expected);
+    },
+  );
+});
 
 describe("composer store", () => {
   beforeEach(() => {

--- a/packages/ui/src/stores/composer.ts
+++ b/packages/ui/src/stores/composer.ts
@@ -63,6 +63,12 @@ export function moreRestrictiveVisibility(a: Visibility, b: Visibility): Visibil
   return (VISIBILITY_RANK[a] ?? 0) >= (VISIBILITY_RANK[b] ?? 0) ? a : b;
 }
 
+/** APIレスポンスの "private" を内部表現 "followers" に正規化する。 */
+export function normalizeVisibility(v: string): Visibility {
+  if (v === "private") return "followers";
+  return v as Visibility;
+}
+
 // --- 下書きストレージ ---
 
 export interface Draft {

--- a/tests/e2e/tests/helpers.ts
+++ b/tests/e2e/tests/helpers.ts
@@ -133,9 +133,9 @@ function crc32(buf: Buffer): number {
  * Create a note via the API. Requires an authenticated page (call loginAsAdmin first).
  * Returns the created note's JSON response.
  */
-export async function createNote(page: Page, text: string) {
+export async function createNote(page: Page, text: string, visibility = "public") {
   const resp = await page.request.post("/api/v1/statuses", {
-    data: { content: text, visibility: "public" },
+    data: { content: text, visibility },
   });
   expect(resp.status()).toBe(201);
   return resp.json();

--- a/tests/e2e/tests/reply-visibility.spec.ts
+++ b/tests/e2e/tests/reply-visibility.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "@playwright/test";
+import { loginAsAdmin, createNote } from "./helpers";
+
+test.describe("Reply Visibility", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test("reply to followers-only note defaults to followers", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `fonly-vis-${uid}`, "followers");
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    // コンポーザーの公開範囲アイコンがロック (followers) であること
+    const visIcon = page.locator(".thread-reply-composer .composer-vis-icon");
+    await expect(visIcon).toBeVisible({ timeout: 5_000 });
+    await expect(visIcon).toHaveText("\u{1F512}");
+  });
+
+  test("warning appears when widening reply visibility", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `warn-vis-${uid}`, "followers");
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    const composer = page.locator(".thread-reply-composer");
+
+    // 初期状態では警告なし
+    await expect(composer.locator(".composer-visibility-warning")).not.toBeVisible();
+
+    // 公開範囲ドロップダウンを開いて public を選択
+    await composer.locator(".composer-vis-toggle").click();
+    await composer.locator(".composer-vis-item").first().click();
+
+    // 警告バナーが表示されること
+    await expect(composer.locator(".composer-visibility-warning")).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("reply to unlisted note defaults to unlisted", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `unlisted-vis-${uid}`, "unlisted");
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    const visIcon = page.locator(".thread-reply-composer .composer-vis-icon");
+    await expect(visIcon).toBeVisible({ timeout: 5_000 });
+    await expect(visIcon).toHaveText("\u{1F513}");
+  });
+
+  test("reply to public note stays public with no warning", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `public-vis-${uid}`);
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    const composer = page.locator(".thread-reply-composer");
+    const visIcon = composer.locator(".composer-vis-icon");
+    await expect(visIcon).toBeVisible({ timeout: 5_000 });
+    await expect(visIcon).toHaveText("\u{1F310}");
+
+    // 警告なし
+    await expect(composer.locator(".composer-visibility-warning")).not.toBeVisible();
+  });
+
+  test("reply to direct note defaults to direct", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `direct-vis-${uid}`, "direct");
+
+    await page.goto(`/notes/${note.id}`);
+    await expect(page.locator(".thread-view")).toBeVisible({ timeout: 10_000 });
+
+    const visIcon = page.locator(".thread-reply-composer .composer-vis-icon");
+    await expect(visIcon).toBeVisible({ timeout: 5_000 });
+    await expect(visIcon).toHaveText("\u2709\uFE0F");
+  });
+
+  test("reply via modal inherits followers visibility", async ({ page }) => {
+    const uid = Date.now();
+    const note = await createNote(page, `modal-vis-${uid}`, "followers");
+
+    // ホームタイムラインで自分の followers-only ノートを見つけてリプライ
+    await page.goto("/?tl=home");
+    await page.waitForSelector(".note-card", { timeout: 10_000 });
+
+    const noteCard = page
+      .locator(".note-card")
+      .filter({ hasText: `modal-vis-${uid}` })
+      .first();
+    await noteCard.locator(".note-reply-btn").click();
+
+    // モーダルが開く
+    await expect(page.locator(".compose-modal-content")).toBeVisible({ timeout: 5_000 });
+
+    // 公開範囲がロック (followers) であること
+    const visIcon = page.locator(".compose-modal-content .composer-vis-icon");
+    await expect(visIcon).toHaveText("\u{1F512}");
+  });
+});


### PR DESCRIPTION
## Summary
- fix: リプライ公開範囲の自動制限が非公開投稿で機能しないバグ修正 (#961)
- fix: CI frontend-build で npm ci を使用しlockfileを尊重
- test: リプライ公開範囲のテストカバレッジ強化 (#962)
- chore: vite 6.4.2 セキュリティアップデート (CVE-2026-39363)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
