### PR TITLE
refactor: 投稿作成APIのクエリ最適化 + ruff lint全修正・CI追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,10 @@ jobs:
         working-directory: backend
         run: pip install -e ".[dev]"
 
+      - name: Lint (ruff)
+        working-directory: backend
+        run: ruff check app/
+
       - name: Run tests (shard ${{ matrix.shard }}/4)
         working-directory: backend
         env:

--- a/backend/app/activitypub/webfinger.py
+++ b/backend/app/activitypub/webfinger.py
@@ -13,10 +13,14 @@ router = APIRouter()
 @router.get("/.well-known/host-meta")
 async def host_meta():
     """LRDD ディスカバリ用の XRD host-meta (Pleroma/GNU Social で使用)。"""
+    template = (
+        f"{settings.server_url}"
+        "/.well-known/webfinger?resource={uri}"
+    )
     xml = (
         '<?xml version="1.0" encoding="UTF-8"?>'
         '<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">'
-        f'<Link rel="lrdd" template="{settings.server_url}/.well-known/webfinger?resource={{uri}}" />'
+        f'<Link rel="lrdd" template="{template}" />'
         "</XRD>"
     )
     return Response(content=xml, media_type="application/xrd+xml")

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -14,11 +14,6 @@ from app.models.follow import Follow
 from app.models.moderation_log import ModerationLog
 from app.models.note import Note
 from app.models.user import User
-from app.schemas.announcement import (
-    AnnouncementAdminResponse,
-    AnnouncementCreateRequest,
-    AnnouncementUpdateRequest,
-)
 from app.schemas.admin import (
     AdminEmojiResponse,
     AdminEmojiUpdate,
@@ -45,6 +40,11 @@ from app.schemas.admin import (
     ServerSettingsResponse,
     ServerSettingsUpdate,
     SystemStatsResponse,
+)
+from app.schemas.announcement import (
+    AnnouncementAdminResponse,
+    AnnouncementCreateRequest,
+    AnnouncementUpdateRequest,
 )
 
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
@@ -780,7 +780,11 @@ async def import_remote_emoji_by_shortcode(
     user: User = Depends(get_permitted_staff("emoji")),
     db: AsyncSession = Depends(get_db),
 ):
-    from app.services.emoji_service import get_custom_emoji, import_remote_emoji_to_local, update_emoji
+    from app.services.emoji_service import (
+        get_custom_emoji,
+        import_remote_emoji_to_local,
+        update_emoji,
+    )
 
     remote = await get_custom_emoji(db, body.shortcode, body.domain)
     if not remote:
@@ -1605,6 +1609,8 @@ async def create_announcement(
     """新しいお知らせを作成する。"""
     from app.services.announcement_service import (
         create_announcement as _create,
+    )
+    from app.services.announcement_service import (
         publish_announcement_event,
     )
 
@@ -1647,8 +1653,10 @@ async def update_announcement(
 ):
     """お知らせを更新する。"""
     from app.services.announcement_service import (
-        update_announcement as _update,
         publish_announcement_event,
+    )
+    from app.services.announcement_service import (
+        update_announcement as _update,
     )
 
     updates = body.model_dump(exclude_unset=True)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -4,6 +4,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Response, UploadFile
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.mastodon.statuses import _to_mastodon_datetime
@@ -458,7 +459,9 @@ async def _credential_account_response(user: User, db: AsyncSession) -> dict:
         "note": actor.summary or "",
         "uri": actor.ap_id,
         "avatar": media_proxy_url(actor.avatar_url, variant="avatar") or DEFAULT_AVATAR_URL,
-        "avatar_static": media_proxy_url(actor.avatar_url, variant="avatar", static=True) or DEFAULT_AVATAR_URL,
+        "avatar_static": media_proxy_url(
+            actor.avatar_url, variant="avatar", static=True,
+        ) or DEFAULT_AVATAR_URL,
         "header": media_proxy_url(actor.header_url) or "",
         "header_static": media_proxy_url(actor.header_url) or "",
         "url": f"{settings.server_url}/@{actor.username}",

--- a/backend/app/api/authorized_apps.py
+++ b/backend/app/api/authorized_apps.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select, func, or_
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_current_user, get_db

--- a/backend/app/api/mastodon/media_proxy.py
+++ b/backend/app/api/mastodon/media_proxy.py
@@ -2,7 +2,7 @@ from urllib.parse import urljoin, urlparse
 
 import httpx
 from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import Response
 
 from app.utils.media_proxy import verify_proxy_hmac
 from app.utils.network import is_private_host as _is_private_host
@@ -102,7 +102,10 @@ async def proxy_media(
                     # 相対URLを絶対URLに解決
                     resolved = urljoin(current_url, location)
                     redirect_parsed = urlparse(resolved)
-                    if redirect_parsed.scheme not in ("http", "https") or not redirect_parsed.hostname:
+                    if (
+                        redirect_parsed.scheme not in ("http", "https")
+                        or not redirect_parsed.hostname
+                    ):
                         raise HTTPException(status_code=403, detail="Invalid redirect URL")
                     if _is_private_host(redirect_parsed.hostname):
                         raise HTTPException(status_code=403, detail="Forbidden redirect host")
@@ -134,7 +137,11 @@ async def proxy_media(
     from app.config import settings
 
     needs_transform = any([avatar, emoji, preview, static, badge])
-    if needs_transform and content_type.startswith("image/") and settings.media_proxy_transform_enabled:
+    if (
+        needs_transform
+        and content_type.startswith("image/")
+        and settings.media_proxy_transform_enabled
+    ):
         body, content_type = await _transform_image(
             body, avatar=avatar, emoji=emoji, preview=preview,
             static=static, badge=badge,

--- a/backend/app/api/mastodon/notifications.py
+++ b/backend/app/api/mastodon/notifications.py
@@ -7,10 +7,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.mastodon.statuses import _to_mastodon_datetime
 from app.dependencies import get_current_user, get_db
 from app.models.custom_emoji import CustomEmoji
 from app.models.user import User
-from app.api.mastodon.statuses import _to_mastodon_datetime
 from app.schemas.note import CustomEmojiInfo, NoteActorResponse
 from app.schemas.notification import NotificationResponse
 from app.utils.media_proxy import media_proxy_url
@@ -121,7 +121,11 @@ async def _notification_to_response(
         )
         sender = notif.sender
         from app.config import settings as app_settings
-        avatar = media_proxy_url(sender.avatar_url, variant="avatar") or f"{app_settings.server_url}/default-avatar.svg"
+        default_avatar = f"{app_settings.server_url}/default-avatar.svg"
+        avatar = (
+            media_proxy_url(sender.avatar_url, variant="avatar")
+            or default_avatar
+        )
         header = media_proxy_url(sender.header_url) or ""
         acct = (
             f"{sender.username}@{sender.domain}" if sender.domain else sender.username

--- a/backend/app/api/mastodon/statuses.py
+++ b/backend/app/api/mastodon/statuses.py
@@ -8,18 +8,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-logger = logging.getLogger(__name__)
-
-
-def _to_mastodon_datetime(dt: datetime | None) -> str:
-    """datetime を Mastodon 互換の ISO 8601 文字列（Z サフィックス付き）にフォーマットする。"""
-    if not dt:
-        return ""
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
-
-
 from app.dependencies import get_current_user, get_db, get_optional_user, require_oauth_scope
 from app.models.note import Note
 from app.models.user import User
@@ -48,6 +36,17 @@ from app.services.note_service import (
     get_reaction_summary,
 )
 from app.utils.media_proxy import media_proxy_url
+
+logger = logging.getLogger(__name__)
+
+
+def _to_mastodon_datetime(dt: datetime | None) -> str:
+    """datetime を Mastodon 互換の ISO 8601 文字列（Z サフィックス付き）にフォーマットする。"""
+    if not dt:
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
 
 _SHORTCODE_RE = re.compile(r":([a-zA-Z0-9_]+):")
 
@@ -697,16 +696,17 @@ async def create_status(
 ):
     # in_reply_to_id の存在を検証
     visibility = "followers" if body.visibility == "private" else body.visibility
+    parent_note = None
     if body.in_reply_to_id:
-        parent = await get_note_by_id(db, body.in_reply_to_id)
-        if not parent:
+        parent_note = await get_note_by_id(db, body.in_reply_to_id)
+        if not parent_note:
             raise HTTPException(status_code=404, detail="Reply target not found")
         # リプライの公開範囲は親ノートより広くできない
         vis_rank = {"public": 0, "unlisted": 1, "followers": 2, "direct": 3}
-        parent_rank = vis_rank.get(parent.visibility, 0)
+        parent_rank = vis_rank.get(parent_note.visibility, 0)
         reply_rank = vis_rank.get(visibility, 0)
         if reply_rank < parent_rank:
-            visibility = parent.visibility
+            visibility = parent_note.visibility
 
     poll_options = None
     poll_expires_in = None
@@ -730,11 +730,28 @@ async def create_status(
             poll_options=poll_options,
             poll_expires_in=poll_expires_in,
             poll_multiple=poll_multiple,
+            parent_note=parent_note,
         )
     except Exception as e:
         logger.exception("Failed to create note")
         raise HTTPException(status_code=422, detail=str(e))
-    return await note_to_response(note, db=db)
+    # 新規ノートの情報からキャッシュを構築し、note_to_response での追加クエリを回避
+    from types import SimpleNamespace
+
+    emoji_cache: dict = {}
+    if hasattr(note, "_emoji_tags") and note._emoji_tags:
+        for et in note._emoji_tags:
+            emoji_cache[(et["shortcode"], None)] = SimpleNamespace(
+                shortcode=et["shortcode"], url=et["url"], static_url=None
+            )
+    hashtags_cache = {note.id: getattr(note, "_hashtag_names", None) or []}
+    return await note_to_response(
+        note,
+        db=db,
+        emoji_cache=emoji_cache,
+        hashtags_cache=hashtags_cache,
+        cards_cache={},  # 新規ノートにはプレビューカードがない
+    )
 
 
 @router.get("/{note_id}", response_model=NoteResponse)

--- a/backend/app/api/mastodon/timelines.py
+++ b/backend/app/api/mastodon/timelines.py
@@ -120,7 +120,8 @@ async def list_timeline(
 ):
     from fastapi import HTTPException
 
-    from app.services.list_service import get_list as get_list_, get_list_timeline
+    from app.services.list_service import get_list as get_list_
+    from app.services.list_service import get_list_timeline
 
     lst = await get_list_(db, list_id)
     if not lst or lst.user_id != user.id:

--- a/backend/app/api/oauth.py
+++ b/backend/app/api/oauth.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode, urlparse
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -635,7 +635,8 @@ def _render_oob_page(*, code: str) -> HTMLResponse:
     """OOB フローの認可コードを表示するページをレンダリングする。"""
     esc = html_mod.escape
     return HTMLResponse(f"""<!DOCTYPE html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Authorization Code</title>
 <style>
 body {{ font-family: sans-serif; max-width: 400px; margin: 40px auto; padding: 0 16px; }}
@@ -669,7 +670,8 @@ def _render_totp_form(
 
     return HTMLResponse(
         f"""<!DOCTYPE html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Two-Factor Authentication</title>
 <style>
 body {{ font-family: sans-serif; max-width: 400px; margin: 40px auto; padding: 0 16px; }}
@@ -744,7 +746,8 @@ def _render_login_form(
 
     return HTMLResponse(
         f"""<!DOCTYPE html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Authorize {esc(app_name)}</title>
 <style>
 body {{ font-family: sans-serif; max-width: 400px; margin: 40px auto; padding: 0 16px; }}
@@ -849,7 +852,8 @@ def _render_consent_form(
 
     return HTMLResponse(
         f"""<!DOCTYPE html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Authorize {esc(app_name)}</title>
 <style>
 body {{ font-family: sans-serif; max-width: 400px; margin: 40px auto; padding: 0 16px; }}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,7 +20,8 @@ class Settings(BaseSettings):
     skip_ssl_verify: bool = False
     allow_private_networks: bool = False  # SSRF 保護を無効化 (連合テスト用)
     face_detect_url: str | None = None
-    face_detect_uds: str | None = None  # face-detect の UDS パス (例: /var/run/nekonoverse-face-detect/uvicorn.sock)
+    # face-detect の UDS パス (例: /var/run/nekonoverse-face-detect/uvicorn.sock)
+    face_detect_uds: str | None = None
     media_proxy_transform_url: str | None = None
     media_proxy_transform_uds: str | None = None
     summary_proxy_url: str | None = None
@@ -139,7 +140,9 @@ if not settings.debug and settings.secret_key in _INSECURE_KEYS:
 
     print(
         "FATAL: SECRET_KEY is not configured. "
-        "Set a strong random value in .env (e.g. python -c \"import secrets; print(secrets.token_hex(32))\")",
+        "Set a strong random value in .env "
+        "(e.g. python -c \"import secrets;"
+        " print(secrets.token_hex(32))\")",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,27 +2,38 @@ from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI, HTTPException, Query
 
-_DEFAULT_FAVICON_SVG = b"""\
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" fill="none">
-  <rect width="180" height="180" rx="36" fill="#f5e6f0"/>
-  <path d="M45 73 L62 28 L79 67Z" fill="#f9a8d4"/>
-  <path d="M135 73 L118 28 L101 67Z" fill="#f9a8d4"/>
-  <path d="M50 70 L62 37 L73 67Z" fill="#fce4ec"/>
-  <path d="M130 70 L118 37 L107 67Z" fill="#fce4ec"/>
-  <circle cx="90" cy="101" r="42" fill="#fff5f5"/>
-  <circle cx="62" cy="112" r="8" fill="#fbb4c8" opacity="0.5"/>
-  <circle cx="118" cy="112" r="8" fill="#fbb4c8" opacity="0.5"/>
-  <ellipse cx="73" cy="95" rx="6" ry="7" fill="#5b4a6a"/>
-  <ellipse cx="107" cy="95" rx="6" ry="7" fill="#5b4a6a"/>
-  <circle cx="75" cy="93" r="2" fill="#fff"/>
-  <circle cx="109" cy="93" r="2" fill="#fff"/>
-  <path d="M87 107 L90 111 L93 107Z" fill="#f9a8d4"/>
-  <path d="M82 114 Q90 121 98 114" stroke="#c48b9f" stroke-width="2" fill="none" stroke-linecap="round"/>
-  <line x1="42" y1="104" x2="65" y2="107" stroke="#d4a0b9" stroke-width="1.5" stroke-linecap="round"/>
-  <line x1="42" y1="112" x2="65" y2="112" stroke="#d4a0b9" stroke-width="1.5" stroke-linecap="round"/>
-  <line x1="115" y1="107" x2="138" y2="104" stroke="#d4a0b9" stroke-width="1.5" stroke-linecap="round"/>
-  <line x1="115" y1="112" x2="138" y2="112" stroke="#d4a0b9" stroke-width="1.5" stroke-linecap="round"/>
-</svg>"""
+_DEFAULT_FAVICON_SVG = (
+    b'<svg xmlns="http://www.w3.org/2000/svg"'
+    b' viewBox="0 0 180 180" fill="none">\n'
+    b'  <rect width="180" height="180" rx="36" fill="#f5e6f0"/>\n'
+    b'  <path d="M45 73 L62 28 L79 67Z" fill="#f9a8d4"/>\n'
+    b'  <path d="M135 73 L118 28 L101 67Z" fill="#f9a8d4"/>\n'
+    b'  <path d="M50 70 L62 37 L73 67Z" fill="#fce4ec"/>\n'
+    b'  <path d="M130 70 L118 37 L107 67Z" fill="#fce4ec"/>\n'
+    b'  <circle cx="90" cy="101" r="42" fill="#fff5f5"/>\n'
+    b'  <circle cx="62" cy="112" r="8" fill="#fbb4c8" opacity="0.5"/>\n'
+    b'  <circle cx="118" cy="112" r="8" fill="#fbb4c8" opacity="0.5"/>\n'
+    b'  <ellipse cx="73" cy="95" rx="6" ry="7" fill="#5b4a6a"/>\n'
+    b'  <ellipse cx="107" cy="95" rx="6" ry="7" fill="#5b4a6a"/>\n'
+    b'  <circle cx="75" cy="93" r="2" fill="#fff"/>\n'
+    b'  <circle cx="109" cy="93" r="2" fill="#fff"/>\n'
+    b'  <path d="M87 107 L90 111 L93 107Z" fill="#f9a8d4"/>\n'
+    b'  <path d="M82 114 Q90 121 98 114" stroke="#c48b9f"'
+    b' stroke-width="2" fill="none" stroke-linecap="round"/>\n'
+    b"  <line x1=\"42\" y1=\"104\" x2=\"65\" y2=\"107\""
+    b' stroke="#d4a0b9" stroke-width="1.5"'
+    b' stroke-linecap="round"/>\n'
+    b"  <line x1=\"42\" y1=\"112\" x2=\"65\" y2=\"112\""
+    b' stroke="#d4a0b9" stroke-width="1.5"'
+    b' stroke-linecap="round"/>\n'
+    b"  <line x1=\"115\" y1=\"107\" x2=\"138\" y2=\"104\""
+    b' stroke="#d4a0b9" stroke-width="1.5"'
+    b' stroke-linecap="round"/>\n'
+    b"  <line x1=\"115\" y1=\"112\" x2=\"138\" y2=\"112\""
+    b' stroke="#d4a0b9" stroke-width="1.5"'
+    b' stroke-linecap="round"/>\n'
+    b"</svg>"
+)
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,16 +43,16 @@ from app.activitypub.routes import router as ap_router
 from app.activitypub.webfinger import router as webfinger_router
 from app.api.admin import router as admin_router
 from app.api.auth import router as auth_router
+from app.api.authorized_apps import router as authorized_apps_router
 from app.api.data_export import router as data_export_router
 from app.api.email_verification import router as email_router
-from app.api.authorized_apps import router as authorized_apps_router
 from app.api.invites import router as invites_router
 from app.api.mastodon.accounts import relationships_router
 from app.api.mastodon.accounts import router as accounts_router
 from app.api.mastodon.bookmarks import router as bookmarks_router
-from app.api.mastodon.lists import router as lists_router
 from app.api.mastodon.compat import router as compat_router
 from app.api.mastodon.follow_requests import router as follow_requests_router
+from app.api.mastodon.lists import router as lists_router
 from app.api.mastodon.media_proxy import router as media_proxy_router
 from app.api.mastodon.notifications import router as notifications_router
 from app.api.mastodon.polls import router as polls_router
@@ -169,7 +180,11 @@ async def _build_contact(db) -> dict:
         actor = result2.scalar_one_or_none()
         if not actor:
             return fallback
-        avatar = media_proxy_url(actor.avatar_url, variant="avatar") or f"{settings.server_url}/default-avatar.svg"
+        default_avatar = f"{settings.server_url}/default-avatar.svg"
+        avatar = (
+            media_proxy_url(actor.avatar_url, variant="avatar")
+            or default_avatar
+        )
         header = media_proxy_url(actor.header_url) or ""
         return {
             "email": admin_user.email or "",
@@ -405,7 +420,6 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
     from sqlalchemy import func, select
 
     from app.models.actor import Actor
-    from app.models.note import Note
     from app.models.user import User
     from app.services.server_settings_service import get_setting
 
@@ -445,8 +459,6 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
         pass
 
     user_count = 0
-    status_count = 0
-    domain_count = 0
     try:
         user_result = await db.execute(
             select(func.count())
@@ -455,16 +467,6 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
             .where(Actor.domain.is_(None), User.is_system.is_(False))
         )
         user_count = user_result.scalar() or 0
-
-        status_result = await db.execute(
-            select(func.count()).select_from(Note).where(Note.local.is_(True))
-        )
-        status_count = status_result.scalar() or 0
-
-        domain_result = await db.execute(
-            select(func.count(func.distinct(Actor.domain))).where(Actor.domain.isnot(None))
-        )
-        domain_count = domain_result.scalar() or 0
     except Exception:
         pass
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,5 @@
-from app.models.announcement import Announcement, AnnouncementDismissal
 from app.models.actor import Actor
+from app.models.announcement import Announcement, AnnouncementDismissal
 from app.models.bookmark import Bookmark
 from app.models.custom_emoji import CustomEmoji
 from app.models.data_export import DataExport
@@ -19,12 +19,12 @@ from app.models.notification import Notification
 from app.models.oauth import OAuthApplication, OAuthAuthorizationCode, OAuthToken
 from app.models.passkey import PasskeyCredential
 from app.models.pinned_note import PinnedNote
+from app.models.poll_vote import PollVote
 from app.models.preview_card import PreviewCard
 from app.models.push_subscription import PushSubscription
-from app.models.poll_vote import PollVote
 from app.models.reaction import Reaction
-from app.models.role import Role
 from app.models.report import Report
+from app.models.role import Role
 from app.models.server_setting import ServerSetting
 from app.models.user import User
 from app.models.user_block import UserBlock

--- a/backend/app/schemas/note.py
+++ b/backend/app/schemas/note.py
@@ -24,7 +24,10 @@ class NoteCreateRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     content: str = Field(default="", max_length=5000, alias="status")
-    visibility: str = Field(default="public", pattern=r"^(public|unlisted|followers|private|direct)$")
+    visibility: str = Field(
+        default="public",
+        pattern=r"^(public|unlisted|followers|private|direct)$",
+    )
     sensitive: bool = False
     spoiler_text: str | None = Field(default=None, max_length=500)
     in_reply_to_id: uuid.UUID | None = None

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import datetime
 
 from pydantic import BaseModel
 

--- a/backend/app/services/drive_service.py
+++ b/backend/app/services/drive_service.py
@@ -237,7 +237,8 @@ async def upload_drive_file(
     _validate_magic_bytes(data, mime_type)
 
     # 保存前にメタデータを除去 (プライバシー保護の多層防御、画像のみ)
-    # media-proxy-rs が有効な場合はデコード→再エンコードで全フォーマットのメタデータ + LSBステガノを除去
+    # media-proxy-rs が有効な場合はデコード→再エンコードで
+    # 全フォーマットのメタデータ + LSBステガノを除去
     # 無効 or 失敗時は従来の strip_exif にフォールバック (JPEG/PNGのみ)
     if mime_type.startswith("image/"):
         transformed = False
@@ -295,6 +296,19 @@ async def upload_drive_file(
 async def get_drive_file(db: AsyncSession, file_id: uuid.UUID) -> DriveFile | None:
     result = await db.execute(select(DriveFile).where(DriveFile.id == file_id))
     return result.scalar_one_or_none()
+
+
+async def get_drive_files_by_ids(
+    db: AsyncSession, file_ids: list[uuid.UUID]
+) -> list[DriveFile]:
+    """複数のドライブファイルを1クエリで取得する。"""
+    if not file_ids:
+        return []
+    result = await db.execute(select(DriveFile).where(DriveFile.id.in_(file_ids)))
+    files = list(result.scalars().all())
+    # 入力順序を保持するためにIDでインデックス化
+    file_map = {f.id: f for f in files}
+    return [file_map[fid] for fid in file_ids if fid in file_map]
 
 
 async def delete_drive_file(db: AsyncSession, drive_file: DriveFile) -> None:

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -98,7 +98,8 @@ def render_password_reset_email(username: str, reset_url: str) -> tuple[str, str
     """パスワードリセット用メールをレンダリングする。(html, text) を返す。"""
     html_body = f"""\
   <p>Hello <strong>{username}</strong>,</p>
-  <p>A password reset was requested for your account. Click the button below to set a new password:</p>
+  <p>A password reset was requested for your account. \
+Click the button below to set a new password:</p>
   <p style="text-align: center; margin: 30px 0;">
     <a href="{reset_url}"
        style="background: #6364ff; color: white; padding: 12px 30px;

--- a/backend/app/services/note_service.py
+++ b/backend/app/services/note_service.py
@@ -56,6 +56,7 @@ async def create_note(
     poll_options: list[str] | None = None,
     poll_expires_in: int | None = None,
     poll_multiple: bool = False,
+    parent_note: "Note | None" = None,
 ) -> Note:
     # CW付きノートは自動的にsensitiveにする (Mastodon互換)
     if spoiler_text and not sensitive:
@@ -81,8 +82,10 @@ async def create_note(
     # direct: to/ccはメンション先アクターのみ (後で処理)
 
     # メンションを抽出してcc/toに追加
+    # mention_actors: 解決済みアクターを保持し、AP配送・通知で再利用する
     mentions = extract_mentions(content)
     mention_data = []
+    mention_actors: list = []
     for username, domain in mentions:
         from app.services.actor_service import actor_uri, get_actor_by_username
 
@@ -105,6 +108,7 @@ async def create_note(
                     "domain": mentioned_actor.domain,
                 }
             )
+            mention_actors.append(mentioned_actor)
             if visibility == "direct":
                 if mentioned_uri not in to_list:
                     to_list.append(mentioned_uri)
@@ -113,21 +117,23 @@ async def create_note(
                     cc_list.append(mentioned_uri)
 
     # リプライ先の解決: AP ID取得 + 作者をcc/toに追加 (AP配送に必要)
+    # parent は後続の返信数インクリメント、AP配送、通知でも再利用する
     in_reply_to_ap_id = None
-    if in_reply_to_id:
+    parent: Note | None = parent_note
+    if in_reply_to_id and not parent:
         parent = await get_note_by_id(db, in_reply_to_id)
-        if parent:
-            in_reply_to_ap_id = parent.ap_id
-            if parent.actor:
-                from app.services.actor_service import actor_uri
+    if parent:
+        in_reply_to_ap_id = parent.ap_id
+        if parent.actor:
+            from app.services.actor_service import actor_uri
 
-                parent_uri = actor_uri(parent.actor)
-                if visibility == "direct":
-                    if parent_uri not in to_list:
-                        to_list.append(parent_uri)
-                else:
-                    if parent_uri not in cc_list:
-                        cc_list.append(parent_uri)
+            parent_uri = actor_uri(parent.actor)
+            if visibility == "direct":
+                if parent_uri not in to_list:
+                    to_list.append(parent_uri)
+            else:
+                if parent_uri not in cc_list:
+                    cc_list.append(parent_uri)
 
     html_content = text_to_html(content)
 
@@ -170,20 +176,18 @@ async def create_note(
             note.poll_expires_at = datetime.now(timezone.utc) + timedelta(seconds=poll_expires_in)
     db.add(note)
 
-    # 親ノートの返信数をインクリメント
-    if in_reply_to_id:
-        parent = await get_note_by_id(db, in_reply_to_id)
-        if parent:
-            parent.replies_count = parent.replies_count + 1
+    # 親ノートの返信数をインクリメント (L118 で取得済みの parent を再利用)
+    if parent:
+        parent.replies_count = parent.replies_count + 1
 
-    # メディアファイルを添付
+    # メディアファイルを添付 (バッチ取得で1クエリに統合)
     if media_ids:
         from app.models.note_attachment import NoteAttachment
-        from app.services.drive_service import get_drive_file
+        from app.services.drive_service import get_drive_files_by_ids
 
-        for position, file_id in enumerate(media_ids[:4]):
-            drive_file = await get_drive_file(db, file_id)
-            if drive_file and drive_file.owner_id == user.id:
+        drive_files = await get_drive_files_by_ids(db, media_ids[:4])
+        for position, drive_file in enumerate(drive_files):
+            if drive_file.owner_id == user.id:
                 attachment = NoteAttachment(
                     note_id=note_id,
                     drive_file_id=drive_file.id,
@@ -205,30 +209,29 @@ async def create_note(
         await upsert_ht(db, note_id, hashtag_names)
         note._hashtag_names = hashtag_names
 
-    # AP連合タグ用にカスタム絵文字ショートコードを抽出
+    # AP連合タグ用にカスタム絵文字ショートコードを抽出 (バッチ取得で1クエリに統合)
     shortcodes = set(_EMOJI_SHORTCODE_RE.findall(content))
     if shortcodes:
-        from app.services.emoji_service import get_custom_emoji
+        from app.services.emoji_service import get_emojis_by_shortcodes
 
-        emoji_tags = []
-        for sc in shortcodes:
-            emoji = await get_custom_emoji(db, sc, None)
-            if emoji and not emoji.local_only:
-                emoji_tags.append(
-                    {
-                        "shortcode": emoji.shortcode,
-                        "url": emoji.url,
-                        "aliases": emoji.aliases,
-                        "license": emoji.license,
-                        "is_sensitive": emoji.is_sensitive,
-                        "author": emoji.author,
-                        "description": emoji.description,
-                        "copy_permission": emoji.copy_permission,
-                        "usage_info": emoji.usage_info,
-                        "is_based_on": emoji.is_based_on,
-                        "category": emoji.category,
-                    }
-                )
+        emojis = await get_emojis_by_shortcodes(db, shortcodes, None)
+        emoji_tags = [
+            {
+                "shortcode": emoji.shortcode,
+                "url": emoji.url,
+                "aliases": emoji.aliases,
+                "license": emoji.license,
+                "is_sensitive": emoji.is_sensitive,
+                "author": emoji.author,
+                "description": emoji.description,
+                "copy_permission": emoji.copy_permission,
+                "usage_info": emoji.usage_info,
+                "is_based_on": emoji.is_based_on,
+                "category": emoji.category,
+            }
+            for emoji in emojis
+            if not emoji.local_only
+        ]
         if emoji_tags:
             note._emoji_tags = emoji_tags
 
@@ -246,23 +249,17 @@ async def create_note(
             follower_inboxes = await get_follower_inboxes(db, actor.id)
             inboxes.update(follower_inboxes)
 
-        # メンション先リモートユーザーへの配送
-        for m in mention_data:
-            if m.get("domain"):
-                from app.services.actor_service import get_actor_by_username
+        # メンション先リモートユーザーへの配送 (解決済みアクターを再利用)
+        for mentioned in mention_actors:
+            if mentioned.domain and mentioned.inbox_url:
+                inbox = mentioned.shared_inbox_url or mentioned.inbox_url
+                inboxes.add(inbox)
 
-                mentioned = await get_actor_by_username(db, m["username"], m["domain"])
-                if mentioned and mentioned.inbox_url:
-                    inbox = mentioned.shared_inbox_url or mentioned.inbox_url
-                    inboxes.add(inbox)
-
-        # リプライ先のリモートユーザーへの配送
-        if in_reply_to_id:
-            parent = await get_note_by_id(db, in_reply_to_id)
-            if parent and parent.actor and parent.actor.domain:
-                inbox = parent.actor.shared_inbox_url or parent.actor.inbox_url
-                if inbox:
-                    inboxes.add(inbox)
+        # リプライ先のリモートユーザーへの配送 (parent は既に取得済み)
+        if parent and parent.actor and parent.actor.domain:
+            inbox = parent.actor.shared_inbox_url or parent.actor.inbox_url
+            if inbox:
+                inboxes.add(inbox)
 
         for inbox_url in inboxes:
             await enqueue_delivery(db, actor.id, inbox_url, activity)
@@ -273,28 +270,24 @@ async def create_note(
     pending_notifs = []
 
     # リプライ先アクターを特定し、メンション+リプライの重複通知を防止
+    # parent は既に取得済み
     reply_recipient_id = None
-    if in_reply_to_id:
-        parent = await get_note_by_id(db, in_reply_to_id)
-        if parent and parent.actor.is_local:
-            reply_recipient_id = parent.actor_id
-            notif = await create_notification(
-                db,
-                "reply",
-                parent.actor_id,
-                actor.id,
-                note_id,
-            )
-            if notif:
-                pending_notifs.append(notif)
+    if parent and parent.actor.is_local:
+        reply_recipient_id = parent.actor_id
+        notif = await create_notification(
+            db,
+            "reply",
+            parent.actor_id,
+            actor.id,
+            note_id,
+        )
+        if notif:
+            pending_notifs.append(notif)
 
-    # メンション通知 (ローカルアクターのみ、リプライ先はスキップ)
-    for m in mention_data:
-        if not m.get("domain"):  # local actor
-            from app.services.actor_service import get_actor_by_username
-
-            mentioned = await get_actor_by_username(db, m["username"], None)
-            if mentioned and mentioned.id != reply_recipient_id:
+    # メンション通知 (ローカルアクターのみ、リプライ先はスキップ、解決済みアクターを再利用)
+    for mentioned in mention_actors:
+        if not mentioned.domain:  # local actor
+            if mentioned.id != reply_recipient_id:
                 notif = await create_notification(
                     db,
                     "mention",
@@ -306,6 +299,9 @@ async def create_note(
                     pending_notifs.append(notif)
 
     await db.commit()
+
+    # 2回目のcommit後にノートを再読み込み（後続処理 + 戻り値で使用）
+    note = await get_note_by_id(db, note_id)
 
     # コミット後に通知イベントをパブリッシュ
     for notif in pending_notifs:
@@ -378,8 +374,7 @@ async def create_note(
     except Exception:
         pass
 
-    # 配送コミット後に最新の状態を取得するため再クエリ
-    return await get_note_by_id(db, note_id)
+    return note
 
 
 _URL_RE = re.compile(r"https?://[^\s<>\"')\]]+")
@@ -1027,9 +1022,10 @@ async def fetch_remote_note(
                     NA.note_id == existing.id,
                     NA.remote_url.isnot(None),
                     NA.remote_focal_x.is_(None),
-                    NA.remote_mime_type.in_(
-                        ["image/jpeg", "image/png", "image/webp", "image/gif", "image/avif", "image/apng"]
-                    ),
+                    NA.remote_mime_type.in_([
+                        "image/jpeg", "image/png", "image/webp",
+                        "image/gif", "image/avif", "image/apng",
+                    ]),
                 )
             )
             att_ids = [row[0] for row in att_rows.all()]
@@ -1349,9 +1345,10 @@ async def fetch_remote_note(
                 NA.note_id == note.id,
                 NA.remote_url.isnot(None),
                 NA.remote_focal_x.is_(None),
-                NA.remote_mime_type.in_(
-                    ["image/jpeg", "image/png", "image/webp", "image/gif", "image/avif", "image/apng"]
-                ),
+                NA.remote_mime_type.in_([
+                    "image/jpeg", "image/png", "image/webp",
+                    "image/gif", "image/avif", "image/apng",
+                ]),
             )
         )
         att_ids = [row[0] for row in att_rows.all()]

--- a/backend/app/services/video_thumb_queue.py
+++ b/backend/app/services/video_thumb_queue.py
@@ -84,7 +84,10 @@ async def _process_local(job: dict) -> None:
             logger.debug("DriveFile %s already has thumbnail, skipping", drive_file_id)
             return
         if drive_file.mime_type not in _VIDEO_MIMES:
-            logger.debug("DriveFile %s is not a video (%s), skipping", drive_file_id, drive_file.mime_type)
+            logger.debug(
+                "DriveFile %s is not a video (%s), skipping",
+                drive_file_id, drive_file.mime_type,
+            )
             return
 
         # S3 から動画をダウンロード
@@ -95,7 +98,10 @@ async def _process_local(job: dict) -> None:
         url = f"{base}/thumbnail" if not base.endswith("/thumbnail") else base
 
         async with make_video_thumb_client() as client:
-            resp = await client.post(url, files={"file": ("video", video_data, drive_file.mime_type)})
+            resp = await client.post(
+                url,
+                files={"file": ("video", video_data, drive_file.mime_type)},
+            )
             resp.raise_for_status()
 
         thumb_data = resp.content

--- a/backend/app/worker/delivery_worker.py
+++ b/backend/app/worker/delivery_worker.py
@@ -101,11 +101,11 @@ async def get_actor_with_key(db: AsyncSession, actor_id: uuid.UUID) -> tuple[Act
 
 async def deliver_activity(job: DeliveryJob, actor: Actor, private_key_pem: str) -> bool:
     """activity をリモート Inbox に配送する。"""
-    from app.config import settings as app_settings
-    from app.utils.network import is_private_host
-
     # SSRF防止: 内部ネットワークへの配送をブロック
     from urllib.parse import urlparse
+
+    from app.config import settings as app_settings
+    from app.utils.network import is_private_host
 
     parsed = urlparse(job.target_inbox_url)
     if not app_settings.allow_private_networks and is_private_host(parsed.hostname or ""):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -49,6 +49,10 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "I"]
 
+[tool.ruff.lint.per-file-ignores]
+# main.py はSVG定数がモジュールレベルimportの前に定義されているため E402 を除外
+"app/main.py" = ["E402"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"


### PR DESCRIPTION
## Summary
- 投稿作成（POST /api/v1/statuses）の重複・N+1クエリを削減し、推定 ~15-30 → ~9-13 クエリに最適化
- ruff lint エラーを全ファイルで修正し、CI に `ruff check` ステップを追加

## 変更内容

### クエリ最適化（note_service.py, drive_service.py, statuses.py）
- 親ノートの重複クエリ除去（`get_note_by_id` 4回→1回、`create_status` からの引き渡し含む）
- メディアファイルの N+1 解消（`get_drive_files_by_ids()` バッチ関数追加、`WHERE id IN (...)` で1クエリ）
- カスタム絵文字の N+1 解消（ループ → `get_emojis_by_shortcodes()` 1クエリ）
- メンションアクターの重複クエリ除去（解決済みアクターを AP 配送・通知で再利用）
- 作成ノートの `get_note_by_id` 重複削減（2回→1回）
- `note_to_response` のキャッシュ活用（emoji/hashtag/card キャッシュを構築して渡す）
- v2 instance エンドポイントの未使用クエリ削除（`status_count`, `domain_count`）

### ruff lint 修正・CI 追加
- E402, E501, I001, F401, F811, F841 を全ファイルで修正
- `pyproject.toml` に `per-file-ignores`（main.py の E402 除外）追加
- `.github/workflows/test.yml` に `ruff check app/` ステップ追加

## Test plan
- [x] `python -m pytest tests/test_api_statuses.py -v` — 78/78 passed
- [x] `python -m pytest tests/ -v` — 1993/1993 passed
- [x] `ruff check app/` — All checks passed

Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
