### PR TITLE
perf: タイムラインAPIのクエリ最適化

### DIFF
--- a/backend/app/api/mastodon/statuses.py
+++ b/backend/app/api/mastodon/statuses.py
@@ -174,6 +174,7 @@ async def note_to_response(
     reblogged_set: set | None = None,
     software_cache: dict | None = None,
     cards_cache: dict | None = None,
+    poll_cache: dict | None = None,
     pinned: bool = False,
 ) -> NoteResponse:
     """Note モデルを NoteResponse に変換する。
@@ -220,6 +221,7 @@ async def note_to_response(
             reblogged_set=reblogged_set,
             software_cache=software_cache,
             cards_cache=cards_cache,
+            poll_cache=poll_cache,
         )
 
     # メディア添付を構築
@@ -240,6 +242,7 @@ async def note_to_response(
             reactions_map=reactions_map,
             software_cache=software_cache,
             cards_cache=cards_cache,
+            poll_cache=poll_cache,
         )
     # フォールバック: quoted_note が未ロードだが quote_id が設定されている場合
     if not quote and db and note.quote_id:
@@ -253,6 +256,7 @@ async def note_to_response(
                 reactions_map=reactions_map,
                 software_cache=software_cache,
                 cards_cache=cards_cache,
+                poll_cache=poll_cache,
             )
     # 引用もリレーション未解決だがquote_ap_idがある場合、遅延解決
     if not quote and db and note.quote_ap_id:
@@ -273,6 +277,7 @@ async def note_to_response(
                     reactions_map=reactions_map,
                     software_cache=software_cache,
                     cards_cache=cards_cache,
+                    poll_cache=poll_cache,
                 )
 
     # content と display_name からカスタム絵文字を解決
@@ -379,12 +384,16 @@ async def note_to_response(
     if note.updated_at:
         edited_at = _to_mastodon_datetime(note.updated_at)
 
-    # 投票レスポンスを構築
+    # 投票レスポンスを構築（バッチキャッシュがあれば使用、なければ個別取得）
     poll_response = None
     if note.is_poll and note.poll_options:
-        from app.services.poll_service import get_poll_data
+        poll_data = None
+        if poll_cache is not None:
+            poll_data = poll_cache.get(note.id)
+        elif db:
+            from app.services.poll_service import get_poll_data
 
-        poll_data = await get_poll_data(db, note.id, actor_id) if db else None
+            poll_data = await get_poll_data(db, note.id, actor_id)
         if poll_data:
             poll_response = PollResponse(**poll_data)
 
@@ -663,6 +672,17 @@ async def notes_to_responses(
     cards_result = await db.execute(select(PreviewCard).where(PreviewCard.note_id.in_(unique_ids)))
     cards_cache: dict = {c.note_id: c for c in cards_result.scalars().all()}
 
+    # 全投票ノートの投票データをバッチ取得（ノートごとの3クエリ→最大3クエリ）
+    from app.services.poll_service import batch_get_poll_data
+
+    all_poll_notes = list(notes)
+    for n in notes:
+        if hasattr(n, "renote_of") and n.renote_of:
+            all_poll_notes.append(n.renote_of)
+        if hasattr(n, "quoted_note") and n.quoted_note:
+            all_poll_notes.append(n.quoted_note)
+    poll_cache = await batch_get_poll_data(db, all_poll_notes, actor_id)
+
     result = []
     for n in notes:
         reactions = reactions_map.get(n.id, [])
@@ -677,6 +697,7 @@ async def notes_to_responses(
             reblogged_set=reblogged_set,
             software_cache=software_cache,
             cards_cache=cards_cache,
+            poll_cache=poll_cache,
             pinned=bool(pinned_ids and n.id in pinned_ids),
         )
         result.append(resp)

--- a/backend/app/api/mastodon/statuses.py
+++ b/backend/app/api/mastodon/statuses.py
@@ -679,6 +679,8 @@ async def notes_to_responses(
     for n in notes:
         if hasattr(n, "renote_of") and n.renote_of:
             all_poll_notes.append(n.renote_of)
+            if hasattr(n.renote_of, "quoted_note") and n.renote_of.quoted_note:
+                all_poll_notes.append(n.renote_of.quoted_note)
         if hasattr(n, "quoted_note") and n.quoted_note:
             all_poll_notes.append(n.quoted_note)
     poll_cache = await batch_get_poll_data(db, all_poll_notes, actor_id)

--- a/backend/app/services/note_service.py
+++ b/backend/app/services/note_service.py
@@ -503,13 +503,22 @@ async def get_note_by_ap_id(db: AsyncSession, ap_id: str) -> Note | None:
 
 
 async def _get_excluded_ids(db: AsyncSession, actor_id: uuid.UUID) -> list[uuid.UUID]:
-    """指定アクターがブロックまたはミュートしているアクターのIDを取得する。"""
-    from app.services.block_service import get_blocked_ids
-    from app.services.mute_service import get_muted_ids
+    """指定アクターがブロックまたはミュートしているアクターIDを1クエリで取得する。"""
+    from sqlalchemy import union_all
 
-    blocked = await get_blocked_ids(db, actor_id)
-    muted = await get_muted_ids(db, actor_id)
-    return list(set(blocked + muted))
+    from app.models.user_block import UserBlock
+    from app.models.user_mute import UserMute
+
+    now = datetime.now(timezone.utc)
+    stmt = union_all(
+        select(UserBlock.target_id).where(UserBlock.actor_id == actor_id),
+        select(UserMute.target_id).where(
+            UserMute.actor_id == actor_id,
+            (UserMute.expires_at.is_(None)) | (UserMute.expires_at > now),
+        ),
+    )
+    result = await db.execute(select(stmt.c.target_id))
+    return list({row[0] for row in result.all()})
 
 
 async def get_public_timeline(
@@ -685,37 +694,48 @@ async def get_home_timeline(
     limit: int = 20,
     max_id: uuid.UUID | None = None,
 ) -> list[Note]:
+    from sqlalchemy import literal, union_all
+
     from app.models.follow import Follow
+    from app.models.list import List, ListMember
+    from app.models.user_block import UserBlock
+    from app.models.user_mute import UserMute
 
     actor_id = user.actor_id
+    now = datetime.now(timezone.utc)
 
-    # このユーザーがフォローしているアクターのIDを取得
-    following_result = await db.execute(
-        select(Follow.following_id).where(
+    # フォロー中 + 自分自身をサブクエリで構築（大量IN句を回避）
+    following_sq = union_all(
+        select(Follow.following_id.label("id")).where(
             Follow.follower_id == actor_id,
             Follow.accepted.is_(True),
-        )
+        ),
+        select(literal(actor_id).label("id")),
     )
-    following_ids = [row[0] for row in following_result.all()]
-    # 自分自身を含める
-    following_ids.append(actor_id)
 
-    # ブロック/ミュート済みアクターを除外
-    excluded = await _get_excluded_ids(db, actor_id)
-    visible_ids = [fid for fid in following_ids if fid not in excluded]
+    # ブロック/ミュート除外サブクエリ
+    excluded_sq = union_all(
+        select(UserBlock.target_id.label("id")).where(UserBlock.actor_id == actor_id),
+        select(UserMute.target_id.label("id")).where(
+            UserMute.actor_id == actor_id,
+            (UserMute.expires_at.is_(None)) | (UserMute.expires_at > now),
+        ),
+    )
 
-    # exclusiveリストに含まれるアクターを除外 (リストTLに表示されるため)
-    from app.services.list_service import get_exclusive_list_actor_ids
-
-    exclusive_ids = await get_exclusive_list_actor_ids(db, user.id)
-    if exclusive_ids:
-        visible_ids = [vid for vid in visible_ids if vid not in exclusive_ids]
+    # exclusiveリスト除外サブクエリ
+    exclusive_sq = (
+        select(ListMember.actor_id)
+        .join(List, ListMember.list_id == List.id)
+        .where(List.user_id == user.id, List.exclusive.is_(True))
+    )
 
     query = (
         select(Note)
         .options(*_note_load_options())
         .where(
-            Note.actor_id.in_(visible_ids),
+            Note.actor_id.in_(select(following_sq.c.id)),
+            Note.actor_id.notin_(select(excluded_sq.c.id)),
+            Note.actor_id.notin_(exclusive_sq),
             Note.deleted_at.is_(None),
             Note.visibility.in_(["public", "unlisted", "followers"]),
         )
@@ -738,18 +758,22 @@ async def get_reaction_summary(
         .group_by(Reaction.emoji)
         .order_by(func.count(Reaction.id).desc())
     )
-    summaries = []
-    for emoji, count in result.all():
-        me = False
-        if current_actor_id:
-            me_result = await db.execute(
-                select(Reaction.id).where(
-                    Reaction.note_id == note_id,
-                    Reaction.actor_id == current_actor_id,
-                    Reaction.emoji == emoji,
-                )
+    rows = result.all()
+
+    # 自分のリアクションを1クエリで事前取得（N+1回避）
+    my_emojis: set[str] = set()
+    if current_actor_id and rows:
+        me_result = await db.execute(
+            select(Reaction.emoji).where(
+                Reaction.note_id == note_id,
+                Reaction.actor_id == current_actor_id,
             )
-            me = me_result.scalar_one_or_none() is not None
+        )
+        my_emojis = {row[0] for row in me_result.all()}
+
+    summaries = []
+    for emoji, count in rows:
+        me = emoji in my_emojis
 
         # カスタム絵文字のURLを解決 (ローカル版を優先)
         emoji_url = None

--- a/backend/app/services/poll_service.py
+++ b/backend/app/services/poll_service.py
@@ -192,3 +192,84 @@ async def get_poll_data(
         "voted": voted,
         "own_votes": own_votes,
     }
+
+
+async def batch_get_poll_data(
+    db: AsyncSession,
+    notes: list[Note],
+    current_actor_id: uuid.UUID | None = None,
+) -> dict[uuid.UUID, dict]:
+    """複数の投票ノートの投票データを3クエリで一括取得する。"""
+    poll_notes = [n for n in notes if n.is_poll and n.poll_options]
+    if not poll_notes:
+        return {}
+
+    note_ids = [n.id for n in poll_notes]
+    now = datetime.now(timezone.utc)
+
+    # 1) ローカル投票ノートの choice_index ごとの投票数を1クエリで取得
+    local_ids = [n.id for n in poll_notes if n.local]
+    vote_counts_map: dict[uuid.UUID, dict[int, int]] = {}
+    if local_ids:
+        vc_result = await db.execute(
+            select(PollVote.note_id, PollVote.choice_index, func.count(PollVote.id))
+            .where(PollVote.note_id.in_(local_ids))
+            .group_by(PollVote.note_id, PollVote.choice_index)
+        )
+        for nid, choice_idx, cnt in vc_result.all():
+            vote_counts_map.setdefault(nid, {})[choice_idx] = cnt
+
+    # 2) ユニーク投票者数を1クエリで取得
+    voters_result = await db.execute(
+        select(PollVote.note_id, func.count(func.distinct(PollVote.actor_id)))
+        .where(PollVote.note_id.in_(note_ids))
+        .group_by(PollVote.note_id)
+    )
+    voters_map = dict(voters_result.all())
+
+    # 3) 現在ユーザーの投票を1クエリで取得
+    own_votes_map: dict[uuid.UUID, list[int]] = {}
+    if current_actor_id:
+        own_result = await db.execute(
+            select(PollVote.note_id, PollVote.choice_index).where(
+                PollVote.note_id.in_(note_ids),
+                PollVote.actor_id == current_actor_id,
+            )
+        )
+        for nid, choice_idx in own_result.all():
+            own_votes_map.setdefault(nid, []).append(choice_idx)
+
+    # 結果を組み立て
+    result: dict[uuid.UUID, dict] = {}
+    for note in poll_notes:
+        options = note.poll_options or []
+        if note.local:
+            vc = vote_counts_map.get(note.id, {})
+            response_options = [
+                {"title": opt.get("title", ""), "votes_count": vc.get(i, 0)}
+                for i, opt in enumerate(options)
+            ]
+            votes_count = sum(vc.values())
+        else:
+            response_options = [
+                {"title": opt.get("title", ""), "votes_count": opt.get("votes_count", 0)}
+                for opt in options
+            ]
+            votes_count = sum(opt.get("votes_count", 0) for opt in options)
+
+        voters_count = voters_map.get(note.id, 0)
+        expired = bool(note.poll_expires_at and note.poll_expires_at < now)
+        own_votes = own_votes_map.get(note.id, [])
+
+        result[note.id] = {
+            "id": str(note.id),
+            "expires_at": note.poll_expires_at.isoformat() if note.poll_expires_at else None,
+            "expired": expired,
+            "multiple": note.poll_multiple,
+            "votes_count": votes_count,
+            "voters_count": voters_count,
+            "options": response_options,
+            "voted": len(own_votes) > 0,
+            "own_votes": own_votes,
+        }
+    return result


### PR DESCRIPTION
## Summary
- `_get_excluded_ids()`: block/mute の2クエリを `UNION ALL` で1クエリに統合
- `get_home_timeline()`: フォロー中IDリスト・除外ID・排他リストIDを全てサブクエリ化し、大量 `IN` 句を回避
- `get_reaction_summary()`: me判定の N+1（絵文字ごとに個別クエリ）を、1クエリで事前バッチ取得に修正
- `batch_get_poll_data()`: 投票データの一括取得関数を追加（ノートごと3クエリ → 全体で最大3クエリ）
- `notes_to_responses()`: poll_cache をバッチ構築して `note_to_response` に渡すように変更

## クエリ削減見積もり
| ケース | Before | After |
|---|---|---|
| タイムライン20件（ポールなし） | ~4 | ~2 |
| タイムライン20件（ポール5件） | ~19 | ~5 |
| 単一ノートのリアクション（5種絵文字） | 6 | 2 |
| ホームTL（フォロー1000人） | IN句1000要素 | サブクエリ |

Closes #971

## Test plan
- [x] ローカルで全1993テスト通過
- [x] ruff lint クリーン
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
