### PR TITLE
perf: アカウントAPI クエリ最適化

### DIFF
--- a/backend/app/api/mastodon/accounts.py
+++ b/backend/app/api/mastodon/accounts.py
@@ -87,13 +87,22 @@ async def get_accounts_batch(
         return []
     result = await db.execute(select(Actor).where(Actor.id.in_(valid_ids)))
     actors = list(result.scalars().all())
+
+    # カウントをバッチ取得（3N→3クエリ）
+    from app.services.follow_service import get_follow_counts_batch
+    from app.services.note_service import get_statuses_count_batch
+
+    visible_ids = [a.id for a in actors if not (a.require_signin_to_view and not user)]
+    follow_counts = await get_follow_counts_batch(db, visible_ids)
+    statuses_counts = await get_statuses_count_batch(db, visible_ids)
+
     accounts = []
     for actor in actors:
         if actor.require_signin_to_view and not user:
             accounts.append(_actor_to_limited_account(actor))
         else:
-            fc, fic = await get_follow_counts(db, actor.id)
-            sc = await get_statuses_count(db, actor.id)
+            fc, fic = follow_counts.get(actor.id, (0, 0))
+            sc = statuses_counts.get(actor.id, 0)
             accounts.append(
                 await _actor_to_account(
                     actor, followers_count=fc, following_count=fic,
@@ -669,40 +678,55 @@ async def get_relationship(
     db: AsyncSession = Depends(get_db),
 ):
     """他のアクターとのフォロー/ブロック/ミュート状態を確認する。"""
-    from app.services.block_service import is_blocking
-    from app.services.mute_service import is_muting
+    from datetime import datetime, timezone
+
+    from sqlalchemy import literal, union_all
+
+    from app.models.user_block import UserBlock
+    from app.models.user_mute import UserMute
 
     following = False
     followed_by = False
     blocking = False
     muting = False
-
-    # フォロー状態の確認 (accepted / pending)
     requested = False
+
+    # フォロー状態の確認（双方向を1クエリで取得）
     result = await db.execute(
-        select(Follow).where(
-            Follow.follower_id == user.actor_id,
-            Follow.following_id == actor_id,
+        select(Follow.follower_id, Follow.following_id, Follow.accepted).where(
+            ((Follow.follower_id == user.actor_id) & (Follow.following_id == actor_id))
+            | ((Follow.follower_id == actor_id) & (Follow.following_id == user.actor_id))
         )
     )
-    outgoing_follow = result.scalar_one_or_none()
-    if outgoing_follow:
-        following = outgoing_follow.accepted
-        requested = not outgoing_follow.accepted
-    else:
-        following = False
+    for row in result.all():
+        if row.follower_id == user.actor_id:
+            following = row.accepted
+            requested = not row.accepted
+        else:
+            if row.accepted:
+                followed_by = True
 
-    result2 = await db.execute(
-        select(Follow).where(
-            Follow.follower_id == actor_id,
-            Follow.following_id == user.actor_id,
-            Follow.accepted.is_(True),
-        )
+    # ブロック/ミュートを1クエリで確認
+    now = datetime.now(timezone.utc)
+    block_mute_q = union_all(
+        select(literal("block").label("type")).where(
+            select(UserBlock.id).where(
+                UserBlock.actor_id == user.actor_id, UserBlock.target_id == actor_id,
+            ).exists()
+        ),
+        select(literal("mute").label("type")).where(
+            select(UserMute.id).where(
+                UserMute.actor_id == user.actor_id, UserMute.target_id == actor_id,
+                (UserMute.expires_at.is_(None)) | (UserMute.expires_at > now),
+            ).exists()
+        ),
     )
-    followed_by = result2.scalar_one_or_none() is not None
-
-    blocking = await is_blocking(db, user.actor_id, actor_id)
-    muting = await is_muting(db, user.actor_id, actor_id)
+    bm_result = await db.execute(select(block_mute_q.c.type))
+    for row in bm_result.all():
+        if row[0] == "block":
+            blocking = True
+        elif row[0] == "mute":
+            muting = True
 
     return {
         "id": str(actor_id),

--- a/backend/app/services/follow_service.py
+++ b/backend/app/services/follow_service.py
@@ -194,6 +194,83 @@ async def get_follow_counts(db: AsyncSession, actor_id: uuid.UUID) -> tuple[int,
     return fc, fic
 
 
+async def get_follow_counts_batch(
+    db: AsyncSession, actor_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, tuple[int, int]]:
+    """複数アクターの (followers_count, following_count) を一括取得する。
+
+    Valkeyキャッシュを優先し、ミス分のみ2クエリでDBから取得。
+    """
+    import json
+
+    from app.valkey_client import valkey
+
+    if not actor_ids:
+        return {}
+
+    result: dict[uuid.UUID, tuple[int, int]] = {}
+
+    # キャッシュから一括取得
+    cache_keys = [f"perf:follow_counts:{aid}" for aid in actor_ids]
+    try:
+        cached_values = await valkey.mget(cache_keys)
+    except Exception:
+        cached_values = [None] * len(actor_ids)
+
+    missing_ids: list[uuid.UUID] = []
+    for aid, cached in zip(actor_ids, cached_values):
+        if cached is not None:
+            try:
+                data = json.loads(cached)
+                result[aid] = (data[0], data[1])
+                continue
+            except Exception:
+                pass
+        missing_ids.append(aid)
+
+    if not missing_ids:
+        return result
+
+    # DBからバッチ取得
+    from sqlalchemy import func
+
+    rows = await db.execute(
+        select(
+            Follow.following_id.label("actor_id"),
+            func.count().label("followers_count"),
+        )
+        .where(Follow.following_id.in_(missing_ids), Follow.accepted.is_(True))
+        .group_by(Follow.following_id)
+    )
+    followers_map = {row.actor_id: row.followers_count for row in rows.all()}
+
+    rows2 = await db.execute(
+        select(
+            Follow.follower_id.label("actor_id"),
+            func.count().label("following_count"),
+        )
+        .where(Follow.follower_id.in_(missing_ids), Follow.accepted.is_(True))
+        .group_by(Follow.follower_id)
+    )
+    following_map = {row.actor_id: row.following_count for row in rows2.all()}
+
+    # 結果を組み立てしキャッシュ
+    try:
+        pipe = valkey.pipeline()
+        for aid in missing_ids:
+            fc = followers_map.get(aid, 0)
+            fic = following_map.get(aid, 0)
+            result[aid] = (fc, fic)
+            pipe.set(f"perf:follow_counts:{aid}", json.dumps([fc, fic]), ex=300)
+        await pipe.execute()
+    except Exception:
+        for aid in missing_ids:
+            if aid not in result:
+                result[aid] = (followers_map.get(aid, 0), following_map.get(aid, 0))
+
+    return result
+
+
 async def get_follower_inboxes(db: AsyncSession, actor_id: uuid.UUID) -> list[str]:
     """アクターの全フォロワーの一意な inbox URL を取得する (配送用)。"""
     result = await db.execute(

--- a/backend/app/services/note_service.py
+++ b/backend/app/services/note_service.py
@@ -986,6 +986,70 @@ async def get_statuses_count(db: AsyncSession, actor_id: uuid.UUID) -> int:
     return count
 
 
+async def get_statuses_count_batch(
+    db: AsyncSession, actor_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, int]:
+    """複数アクターのステータス数を一括取得する。
+
+    Valkeyキャッシュを優先し、ミス分のみ1クエリでDBから取得。
+    """
+    import json
+
+    from app.valkey_client import valkey
+
+    if not actor_ids:
+        return {}
+
+    result: dict[uuid.UUID, int] = {}
+
+    # キャッシュから一括取得
+    cache_keys = [f"perf:statuses_count:{aid}" for aid in actor_ids]
+    try:
+        cached_values = await valkey.mget(cache_keys)
+    except Exception:
+        cached_values = [None] * len(actor_ids)
+
+    missing_ids: list[uuid.UUID] = []
+    for aid, cached in zip(actor_ids, cached_values):
+        if cached is not None:
+            try:
+                result[aid] = json.loads(cached)
+                continue
+            except Exception:
+                pass
+        missing_ids.append(aid)
+
+    if not missing_ids:
+        return result
+
+    # DBからバッチ取得
+    rows = await db.execute(
+        select(Note.actor_id, func.count().label("cnt"))
+        .where(
+            Note.actor_id.in_(missing_ids),
+            Note.visibility.in_(["public", "unlisted"]),
+            Note.deleted_at.is_(None),
+        )
+        .group_by(Note.actor_id)
+    )
+    counts_map = {row.actor_id: row.cnt for row in rows.all()}
+
+    # 結果を組み立てしキャッシュ
+    try:
+        pipe = valkey.pipeline()
+        for aid in missing_ids:
+            count = counts_map.get(aid, 0)
+            result[aid] = count
+            pipe.set(f"perf:statuses_count:{aid}", json.dumps(count), ex=300)
+        await pipe.execute()
+    except Exception:
+        for aid in missing_ids:
+            if aid not in result:
+                result[aid] = counts_map.get(aid, 0)
+
+    return result
+
+
 _FETCH_MAX_DEPTH = 3
 
 


### PR DESCRIPTION
## Summary
- `get_follow_counts_batch()`: Valkey `mget` + DB 2クエリで複数アクターのフォロー数を一括取得（2N→2クエリ）
- `get_statuses_count_batch()`: Valkey `mget` + DB 1クエリでステータス数を一括取得（N→1クエリ）
- `get_accounts_batch()`: ループ内の個別 `get_follow_counts`/`get_statuses_count` をバッチに置換
- `get_relationship()`: 4逐次クエリを2クエリに統合（フォロー双方向1クエリ + block/mute UNION ALL 1クエリ）

## クエリ削減見積もり
| ケース | Before | After |
|---|---|---|
| アカウント一括取得40件（キャッシュミス） | ~120 | ~3 |
| リレーション確認 | 4 | 2 |

Closes #972

## Test plan
- [x] ローカルで全1993テスト通過
- [x] ruff lint クリーン
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
