### PR TITLE
perf: AP受信処理のクエリ最適化

### DIFF
--- a/backend/app/activitypub/handlers/create.py
+++ b/backend/app/activitypub/handlers/create.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.activitypub import extract_mfm_source
 from app.config import settings
 from app.models.note import Note
-from app.services.actor_service import fetch_remote_actor, get_actor_by_ap_id
+from app.services.actor_service import fetch_remote_actor, get_actor_by_ap_id, get_actors_by_ap_ids
 from app.services.note_service import fetch_remote_note, get_note_by_ap_id
 from app.utils.sanitize import sanitize_html
 
@@ -368,8 +368,11 @@ async def handle_create_note(db: AsyncSession, activity: dict, note_data: dict):
                 if notif:
                     pending_notifs.append(notif)
 
+    # メンションアクターをバッチ取得（N+1回避）
+    mention_ap_ids = [m["ap_id"] for m in mentions_list if m.get("ap_id")]
+    mentioned_actors = await get_actors_by_ap_ids(db, mention_ap_ids) if mention_ap_ids else {}
     for mention in mentions_list:
-        mentioned_actor = await get_actor_by_ap_id(db, mention["ap_id"])
+        mentioned_actor = mentioned_actors.get(mention["ap_id"])
         if (
             mentioned_actor
             and mentioned_actor.is_local

--- a/backend/app/services/actor_service.py
+++ b/backend/app/services/actor_service.py
@@ -62,6 +62,44 @@ async def get_actor_by_ap_id(db: AsyncSession, ap_id: str) -> Actor | None:
     return None
 
 
+async def get_actors_by_ap_ids(db: AsyncSession, ap_ids: list[str]) -> dict[str, Actor]:
+    """複数の AP ID からアクターを一括取得する。
+
+    Returns:
+        ap_id -> Actor のマッピング。見つからないAPIDは含まれない。
+    """
+    if not ap_ids:
+        return {}
+
+    result = await db.execute(select(Actor).where(Actor.ap_id.in_(ap_ids)))
+    actors_map = {a.ap_id: a for a in result.scalars().all()}
+
+    # フォールバック: 見つからないap_idがローカルアクターURLの形式なら、ユーザー名で検索
+    from urllib.parse import urlparse
+
+    missing_local: dict[str, str] = {}  # ap_id -> username
+    for ap_id in ap_ids:
+        if ap_id in actors_map:
+            continue
+        parsed = urlparse(ap_id)
+        if parsed.hostname == settings.domain and parsed.path.startswith("/users/"):
+            username = parsed.path.split("/users/", 1)[1].rstrip("/")
+            if username:
+                missing_local[ap_id] = username
+
+    if missing_local:
+        usernames = list(missing_local.values())
+        local_result = await db.execute(
+            select(Actor).where(Actor.username.in_(usernames), Actor.domain.is_(None))
+        )
+        local_by_username = {a.username: a for a in local_result.scalars().all()}
+        for ap_id, username in missing_local.items():
+            if username in local_by_username:
+                actors_map[ap_id] = local_by_username[username]
+
+    return actors_map
+
+
 async def get_actor_by_username(
     db: AsyncSession,
     username: str,

--- a/backend/app/services/actor_service.py
+++ b/backend/app/services/actor_service.py
@@ -88,14 +88,14 @@ async def get_actors_by_ap_ids(db: AsyncSession, ap_ids: list[str]) -> dict[str,
                 missing_local[ap_id] = username
 
     if missing_local:
-        usernames = list(missing_local.values())
+        usernames = [u.lower() for u in missing_local.values()]
         local_result = await db.execute(
             select(Actor).where(Actor.username.in_(usernames), Actor.domain.is_(None))
         )
         local_by_username = {a.username: a for a in local_result.scalars().all()}
         for ap_id, username in missing_local.items():
-            if username in local_by_username:
-                actors_map[ap_id] = local_by_username[username]
+            if username.lower() in local_by_username:
+                actors_map[ap_id] = local_by_username[username.lower()]
 
     return actors_map
 

--- a/backend/app/services/note_service.py
+++ b/backend/app/services/note_service.py
@@ -517,7 +517,8 @@ async def _get_excluded_ids(db: AsyncSession, actor_id: uuid.UUID) -> list[uuid.
             (UserMute.expires_at.is_(None)) | (UserMute.expires_at > now),
         ),
     )
-    result = await db.execute(select(stmt.c.target_id))
+    subq = stmt.subquery()
+    result = await db.execute(select(subq.c.target_id))
     return list({row[0] for row in result.all()})
 
 
@@ -733,8 +734,8 @@ async def get_home_timeline(
         select(Note)
         .options(*_note_load_options())
         .where(
-            Note.actor_id.in_(select(following_sq.c.id)),
-            Note.actor_id.notin_(select(excluded_sq.c.id)),
+            Note.actor_id.in_(select(following_sq.subquery().c.id)),
+            Note.actor_id.notin_(select(excluded_sq.subquery().c.id)),
             Note.actor_id.notin_(exclusive_sq),
             Note.deleted_at.is_(None),
             Note.visibility.in_(["public", "unlisted", "followers"]),


### PR DESCRIPTION
## Summary
- `get_actors_by_ap_ids()`: 複数 AP ID からアクターを1クエリでバッチ取得する関数を追加（ローカルURLフォールバック付き）
- AP Create handler: メンション解決のN+1ループを `get_actors_by_ap_ids` バッチに置換
- `_get_excluded_ids`/`get_home_timeline`: SQLAlchemy `SelectBase.c` deprecation warning を `.subquery()` で修正

## クエリ削減見積もり
| ケース | Before | After |
|---|---|---|
| メンション10件のノート受信 | 10 | 1-2 |

Closes #974

## Test plan
- [x] ローカルで全1993テスト通過
- [x] ruff lint クリーン
- [x] SQLAlchemy deprecation warning 解消
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
