### PR TITLE
feat: メディアタイムラインのセンシティブブラー一括解除

### DIFF
--- a/frontend/src/pages/MediaTimeline.tsx
+++ b/frontend/src/pages/MediaTimeline.tsx
@@ -12,6 +12,8 @@ export default function MediaTimeline() {
   const [loadingMore, setLoadingMore] = createSignal(false);
   const [hasMore, setHasMore] = createSignal(true);
   const [threadNoteId, setThreadNoteId] = createSignal<string | null>(null);
+  const [showSensitive, setShowSensitive] = createSignal(false);
+  const [showSensitiveModal, setShowSensitiveModal] = createSignal(false);
 
   let sentinelRef: HTMLDivElement | undefined;
   let observer: IntersectionObserver | undefined;
@@ -99,6 +101,20 @@ export default function MediaTimeline() {
             onInput={(e) => handleSearchInput(e.currentTarget.value)}
             class="media-timeline-search-input"
           />
+          <button
+            class={`media-timeline-sensitive-toggle ${showSensitive() ? "active" : ""}`}
+            onClick={() => {
+              if (showSensitive()) {
+                setShowSensitive(false);
+              } else {
+                setShowSensitiveModal(true);
+              }
+            }}
+          >
+            {showSensitive()
+              ? t("mediaTimeline.hideSensitive")
+              : t("mediaTimeline.showSensitive")}
+          </button>
         </div>
         <Show
           when={initialData.state === "ready" || notes().length > 0}
@@ -121,7 +137,7 @@ export default function MediaTimeline() {
                         onClick={() => setThreadNoteId(note.id)}
                       >
                         <Show
-                          when={!target().sensitive}
+                          when={!target().sensitive || showSensitive()}
                           fallback={
                             <div class="media-gallery-sensitive">
                               <img
@@ -191,6 +207,38 @@ export default function MediaTimeline() {
           noteId={threadNoteId()!}
           onClose={() => setThreadNoteId(null)}
         />
+      </Show>
+      <Show when={showSensitiveModal()}>
+        <div
+          class="modal-overlay confirm-overlay"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setShowSensitiveModal(false);
+          }}
+        >
+          <div class="confirm-dialog">
+            <h3 class="confirm-dialog-title">
+              {t("mediaTimeline.sensitiveModal.title")}
+            </h3>
+            <p>{t("mediaTimeline.sensitiveModal.message")}</p>
+            <div class="confirm-actions">
+              <button
+                class="confirm-btn confirm-discard"
+                onClick={() => setShowSensitiveModal(false)}
+              >
+                {t("mediaTimeline.sensitiveModal.cancel")}
+              </button>
+              <button
+                class="confirm-btn confirm-save"
+                onClick={() => {
+                  setShowSensitive(true);
+                  setShowSensitiveModal(false);
+                }}
+              >
+                {t("mediaTimeline.sensitiveModal.confirm")}
+              </button>
+            </div>
+          </div>
+        </div>
       </Show>
     </div>
   );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -8351,6 +8351,9 @@ html[data-cursor="paw"] [contenteditable="true"] {
 
 .media-timeline-search {
   margin-bottom: 16px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
 }
 
 .media-timeline-search-input {
@@ -8368,6 +8371,41 @@ html[data-cursor="paw"] [contenteditable="true"] {
 
 .media-timeline-search-input:focus {
   border-color: var(--accent);
+}
+
+.media-timeline-sensitive-toggle {
+  flex-shrink: 0;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.media-timeline-sensitive-toggle:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.media-timeline-sensitive-toggle.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.media-timeline-sensitive-toggle.active:hover {
+  background: var(--accent-hover);
+}
+
+.confirm-dialog-title {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
 }
 
 .media-gallery-grid {

--- a/packages/ui/src/i18n/dictionaries/en.ts
+++ b/packages/ui/src/i18n/dictionaries/en.ts
@@ -853,6 +853,12 @@ export const en: Dictionary = {
   "mediaTimeline.title": "Media Timeline",
   "mediaTimeline.searchPlaceholder": "Search tags, captions, content...",
   "mediaTimeline.empty": "No posts with media yet.",
+  "mediaTimeline.showSensitive": "Show sensitive",
+  "mediaTimeline.hideSensitive": "Hide sensitive",
+  "mediaTimeline.sensitiveModal.title": "Show sensitive media",
+  "mediaTimeline.sensitiveModal.message": "This will reveal all media marked as sensitive. Are you sure?",
+  "mediaTimeline.sensitiveModal.confirm": "Reveal",
+  "mediaTimeline.sensitiveModal.cancel": "Cancel",
 
   "themeCustomizer.colors": "Customize Colors",
   "themeCustomizer.bgPrimary": "Background",

--- a/packages/ui/src/i18n/dictionaries/ja.ts
+++ b/packages/ui/src/i18n/dictionaries/ja.ts
@@ -849,6 +849,12 @@ export const ja = {
   "mediaTimeline.title": "メディアタイムライン",
   "mediaTimeline.searchPlaceholder": "タグ・キャプション・本文で検索...",
   "mediaTimeline.empty": "メディア付きの投稿がありません。",
+  "mediaTimeline.showSensitive": "センシティブを表示",
+  "mediaTimeline.hideSensitive": "センシティブを隠す",
+  "mediaTimeline.sensitiveModal.title": "センシティブなメディアの表示",
+  "mediaTimeline.sensitiveModal.message": "センシティブとしてマークされたすべてのメディアのぼかしを解除します。よろしいですか？",
+  "mediaTimeline.sensitiveModal.confirm": "解除する",
+  "mediaTimeline.sensitiveModal.cancel": "キャンセル",
 
   "themeCustomizer.colors": "カラーカスタマイズ",
   "themeCustomizer.bgPrimary": "背景",

--- a/packages/ui/src/i18n/dictionaries/neko.ts
+++ b/packages/ui/src/i18n/dictionaries/neko.ts
@@ -851,6 +851,12 @@ export const neko: Dictionary = {
   "mediaTimeline.title": "めでぃあたいむらいんにゃ",
   "mediaTimeline.searchPlaceholder": "けんさくにゃ...",
   "mediaTimeline.empty": "めでぃあつきのとうこうがにゃいにゃ。",
+  "mediaTimeline.showSensitive": "せんしてぃぶをみるにゃ",
+  "mediaTimeline.hideSensitive": "せんしてぃぶをかくすにゃ",
+  "mediaTimeline.sensitiveModal.title": "せんしてぃぶなめでぃあのひょうじにゃ",
+  "mediaTimeline.sensitiveModal.message": "せんしてぃぶなめでぃあのぼかしをぜんぶかいじょするにゃ。いいにゃ？",
+  "mediaTimeline.sensitiveModal.confirm": "かいじょするにゃ",
+  "mediaTimeline.sensitiveModal.cancel": "やめるにゃ",
 
   "themeCustomizer.colors": "いろをカスタマイズにゃ",
   "themeCustomizer.bgPrimary": "はいけいにゃ",


### PR DESCRIPTION
## Summary
- メディアタイムラインにセンシティブコンテンツの一括表示/非表示トグルを追加
- トグルボタンクリック時は確認モーダルを必ず表示（直接解除しない）
- 再ブラーはモーダルなしで即座に可能

## Changes
- `MediaTimeline.tsx`: `showSensitive`/`showSensitiveModal` シグナル追加、トグルボタン、確認モーダル
- `global.css`: トグルボタンとモーダルタイトルのスタイル
- `ja.ts`/`en.ts`/`neko.ts`: 6 i18n キー追加

Closes #982

## Test plan
- [ ] メディアタイムラインでセンシティブ画像がブラーされていることを確認
- [ ] 「センシティブを表示」ボタンをクリックし、確認モーダルが表示されることを確認
- [ ] モーダルの「キャンセル」で解除されないことを確認
- [ ] モーダルの「解除する」で全画像のブラーが解除されることを確認
- [ ] 「センシティブを隠す」ボタンで即座にブラーが復元されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
