### PR TITLE
fix: 配送失敗時の HTTP ステータスとレスポンスボディを error_message に記録 (#993)

### DIFF
--- a/backend/app/worker/delivery_worker.py
+++ b/backend/app/worker/delivery_worker.py
@@ -99,8 +99,23 @@ async def get_actor_with_key(db: AsyncSession, actor_id: uuid.UUID) -> tuple[Act
     return actor, actor.local_user.private_key_pem
 
 
-async def deliver_activity(job: DeliveryJob, actor: Actor, private_key_pem: str) -> bool:
-    """activity をリモート Inbox に配送する。"""
+# 配送失敗時にエラーメッセージへ残すレスポンスボディの最大長。
+# 診断に必要なシグナル（先頭のエラーメッセージ）は確保しつつ、巨大な HTML や PII の流入を防ぐ。
+_ERROR_BODY_PREVIEW_MAX = 300
+
+
+async def deliver_activity(
+    job: DeliveryJob, actor: Actor, private_key_pem: str
+) -> tuple[bool, int, str]:
+    """activity をリモート Inbox に配送する。
+
+    Returns:
+        tuple of ``(success, status_code, error_detail)``.
+        - ``success``: 2xx/204 を受け取れたか
+        - ``status_code``: HTTP ステータスコード。レスポンス未受信時は 0
+        - ``error_detail``: 成功時は空文字。失敗時は ``"HTTP 503: <body>"`` や
+          ``"ConnectError: <detail>"`` のような診断可能な文字列
+    """
     # SSRF防止: 内部ネットワークへの配送をブロック
     from urllib.parse import urlparse
 
@@ -110,7 +125,7 @@ async def deliver_activity(job: DeliveryJob, actor: Actor, private_key_pem: str)
     parsed = urlparse(job.target_inbox_url)
     if not app_settings.allow_private_networks and is_private_host(parsed.hostname or ""):
         logger.warning("Blocked delivery to private host: %s", job.target_inbox_url)
-        return False
+        return False, 0, "Blocked: private host"
 
     body = json.dumps(job.payload).encode("utf-8")
     # 正しいスキームを保証するためローカルアクターの動的 URL を使用
@@ -130,12 +145,25 @@ async def deliver_activity(job: DeliveryJob, actor: Actor, private_key_pem: str)
 
     from app.config import settings
 
-    resp = await _get_http_client(settings).post(
-        job.target_inbox_url,
-        content=body,
-        headers=headers,
-    )
-    return resp.status_code in (200, 202, 204)
+    try:
+        resp = await _get_http_client(settings).post(
+            job.target_inbox_url,
+            content=body,
+            headers=headers,
+        )
+    except Exception as e:
+        # httpx.ConnectError / TimeoutException / RemoteProtocolError など。
+        # 例外クラス名を残すことで後続の集計 (タイムアウト多発、SSL 失敗 etc.) を可能にする。
+        return False, 0, f"{type(e).__name__}: {str(e)[:_ERROR_BODY_PREVIEW_MAX]}"
+
+    if resp.status_code in (200, 202, 204):
+        return True, resp.status_code, ""
+
+    try:
+        body_preview = (resp.text or "")[:_ERROR_BODY_PREVIEW_MAX]
+    except Exception:
+        body_preview = ""
+    return False, resp.status_code, f"HTTP {resp.status_code}: {body_preview}".rstrip(": ")
 
 
 async def _deliver_one(job_id: uuid.UUID, sem: asyncio.Semaphore) -> None:
@@ -154,19 +182,29 @@ async def _deliver_one(job_id: uuid.UUID, sem: asyncio.Semaphore) -> None:
                 return
 
             try:
-                success = await deliver_activity(job, actor, private_key_pem)
-                if success:
-                    job.status = "delivered"
-                    logger.info("Delivered to %s", job.target_inbox_url)
-                else:
-                    raise Exception("Non-success status code")
+                success, status_code, error_detail = await deliver_activity(
+                    job, actor, private_key_pem
+                )
             except Exception as e:
+                # deliver_activity は想定される例外を握り潰す設計だが、
+                # sign_request 等の内部で想定外が出た場合のフォールバック。
+                logger.exception(
+                    "Unexpected error during delivery to %s", job.target_inbox_url
+                )
+                success = False
+                status_code = 0
+                error_detail = f"Unexpected {type(e).__name__}: {str(e)[:300]}"
+
+            if success:
+                job.status = "delivered"
+                logger.info("Delivered to %s (HTTP %d)", job.target_inbox_url, status_code)
+            else:
                 logger.warning(
                     "Delivery failed to %s (attempt %d/%d): %s",
                     job.target_inbox_url,
                     job.attempts,
                     job.max_attempts,
-                    str(e),
+                    error_detail,
                 )
                 if job.attempts >= job.max_attempts:
                     job.status = "dead"
@@ -174,7 +212,7 @@ async def _deliver_one(job_id: uuid.UUID, sem: asyncio.Semaphore) -> None:
                     job.status = "pending"
                     delay = min(60 * (2**job.attempts), 21600)  # Max 6 hours
                     job.next_retry_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
-                job.error_message = str(e)
+                job.error_message = error_detail
 
             await db.commit()
 

--- a/backend/tests/test_delivery_worker.py
+++ b/backend/tests/test_delivery_worker.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from sqlalchemy import select
 
 from app.models.delivery import DeliveryJob
 from app.worker.delivery_worker import (
@@ -149,7 +148,7 @@ async def test_get_actor_with_key_nonexistent(db, mock_valkey):
 # ── deliver_activity ──
 
 
-def _mock_httpx_client(status_code=202, side_effect=None):
+def _mock_httpx_client(status_code=202, side_effect=None, text=""):
     """Helper to create a mocked httpx client for _get_http_client."""
     mock_client = AsyncMock()
     if side_effect:
@@ -157,6 +156,7 @@ def _mock_httpx_client(status_code=202, side_effect=None):
     else:
         mock_response = MagicMock()
         mock_response.status_code = status_code
+        mock_response.text = text
         mock_client.post = AsyncMock(return_value=mock_response)
     return mock_client
 
@@ -169,23 +169,84 @@ async def test_deliver_activity_success(db, test_user, pending_job, mock_valkey)
         patch("app.worker.delivery_worker._get_http_client", return_value=mock_client),
         patch("app.utils.network.is_private_host", return_value=False),
     ):
-        result = await deliver_activity(pending_job, actor, test_user.private_key_pem)
+        success, status_code, error_detail = await deliver_activity(
+            pending_job, actor, test_user.private_key_pem
+        )
 
-    assert result is True
+    assert success is True
+    assert status_code == 202
+    assert error_detail == ""
     mock_client.post.assert_called_once()
 
 
 async def test_deliver_activity_failure_500(db, test_user, pending_job, mock_valkey):
     actor = test_user.actor
-    mock_client = _mock_httpx_client(500)
+    mock_client = _mock_httpx_client(500, text="upstream exploded")
 
     with (
         patch("app.worker.delivery_worker._get_http_client", return_value=mock_client),
         patch("app.utils.network.is_private_host", return_value=False),
     ):
-        result = await deliver_activity(pending_job, actor, test_user.private_key_pem)
+        success, status_code, error_detail = await deliver_activity(
+            pending_job, actor, test_user.private_key_pem
+        )
 
-    assert result is False
+    assert success is False
+    assert status_code == 500
+    assert "HTTP 500" in error_detail
+    assert "upstream exploded" in error_detail
+
+
+async def test_deliver_activity_error_detail_truncates_body(
+    db, test_user, pending_job, mock_valkey
+):
+    huge_body = "x" * 10_000
+    mock_client = _mock_httpx_client(400, text=huge_body)
+
+    with (
+        patch("app.worker.delivery_worker._get_http_client", return_value=mock_client),
+        patch("app.utils.network.is_private_host", return_value=False),
+    ):
+        _, _, error_detail = await deliver_activity(
+            pending_job, test_user.actor, test_user.private_key_pem
+        )
+
+    # 先頭 300 文字 + "HTTP 400: " のプレフィックスで十分短い
+    assert len(error_detail) < 400
+
+
+async def test_deliver_activity_network_exception_returns_type_name(
+    db, test_user, pending_job, mock_valkey
+):
+    import httpx
+
+    mock_client = _mock_httpx_client(side_effect=httpx.ConnectError("all attempts failed"))
+
+    with (
+        patch("app.worker.delivery_worker._get_http_client", return_value=mock_client),
+        patch("app.utils.network.is_private_host", return_value=False),
+    ):
+        success, status_code, error_detail = await deliver_activity(
+            pending_job, test_user.actor, test_user.private_key_pem
+        )
+
+    assert success is False
+    assert status_code == 0
+    assert "ConnectError" in error_detail
+    assert "all attempts failed" in error_detail
+
+
+async def test_deliver_activity_private_host_blocked(
+    db, test_user, pending_job, mock_valkey
+):
+    with patch("app.utils.network.is_private_host", return_value=True):
+        success, status_code, error_detail = await deliver_activity(
+            pending_job, test_user.actor, test_user.private_key_pem
+        )
+
+    assert success is False
+    assert status_code == 0
+    assert "private host" in error_detail
 
 
 async def test_deliver_activity_accepts_200(db, test_user, pending_job, mock_valkey):
@@ -196,9 +257,11 @@ async def test_deliver_activity_accepts_200(db, test_user, pending_job, mock_val
         patch("app.worker.delivery_worker._get_http_client", return_value=mock_client),
         patch("app.utils.network.is_private_host", return_value=False),
     ):
-        result = await deliver_activity(pending_job, actor, test_user.private_key_pem)
+        success, _, _ = await deliver_activity(
+            pending_job, actor, test_user.private_key_pem
+        )
 
-    assert result is True
+    assert success is True
 
 
 async def test_deliver_activity_accepts_204(db, test_user, pending_job, mock_valkey):
@@ -209,9 +272,11 @@ async def test_deliver_activity_accepts_204(db, test_user, pending_job, mock_val
         patch("app.worker.delivery_worker._get_http_client", return_value=mock_client),
         patch("app.utils.network.is_private_host", return_value=False),
     ):
-        result = await deliver_activity(pending_job, actor, test_user.private_key_pem)
+        success, _, _ = await deliver_activity(
+            pending_job, actor, test_user.private_key_pem
+        )
 
-    assert result is True
+    assert success is True
 
 
 async def test_deliver_activity_sends_signed_headers(db, test_user, pending_job, mock_valkey):


### PR DESCRIPTION
## 概要

配送失敗の診断性を改善する。これまで非 2xx 応答は全て \"Non-success status code\" という同一文字列で error_message に記録されていたため、配送失敗の原因を集計できなかった（本番で 1059 件が同一文字列）。

Closes #993

## 変更内容

- \`deliver_activity\` の戻り値を \`bool\` → \`tuple[bool, int, str]\`
  - 失敗時: \`\"HTTP 503: <body preview>\"\` や \`\"ConnectError: <detail>\"\`
  - 成功時: \`(True, status_code, \"\")\`
- \`_deliver_one\` で tuple を受け取り \`job.error_message\` に記録
- レスポンスボディは **300 文字で切り詰め**（PII・巨大レスポンス対策）
- ネットワーク系例外は **例外クラス名を保持**（ConnectError / TimeoutException 等の集計が可能に）

## 想定される効果

デプロイ後、以下のような具体的なエラー分布が取れる想定:

\`\`\`
HTTP 503: upstream connect error               xxx
HTTP 401: signature validation failed          xxx
ConnectError: [Errno 111] Connection refused   xxx
TimeoutException:                              xxx
\`\`\`

これにより #992 の孤児ジョブ調査も容易になる。

## Test plan

- [x] 既存 22 テストを tuple 形式に合わせて更新、全てパス
- [x] 新規テスト 4 件追加（HTTP エラー本文含有、ボディ切り詰め、例外型名、SSRF ブロック）
- [x] \`ruff check\` クリア
- [x] \`tests/test_delivery_worker.py\` 26 件、\`tests/test_service_delivery.py\` 30 件すべてパス
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
