### PR TITLE
fix: 孤児 processing ジョブの定期回収を追加 (#992)

### DIFF
--- a/backend/app/worker/delivery_worker.py
+++ b/backend/app/worker/delivery_worker.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 import httpx
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -22,6 +22,13 @@ logger = logging.getLogger(__name__)
 AP_CONTENT_TYPE = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
 
 MAX_CONCURRENT = 16
+
+# 孤児ジョブ回収の閾値。worker がクラッシュ/再起動で status='processing' のまま
+# 残したジョブをこの時間経過後に pending に戻す。配送タイムアウト (30s) と
+# 処理時間を含めても数分あれば十分。
+ORPHAN_RECLAIM_THRESHOLD = timedelta(minutes=10)
+# ループ中に孤児回収を走らせる間隔。
+ORPHAN_RECLAIM_INTERVAL = timedelta(minutes=1)
 
 # L-1: 署名鍵キャッシュ (actor_id -> (Actor, private_key_pem, cached_at))
 _signing_key_cache: dict[uuid.UUID, tuple[Actor, str, float]] = {}
@@ -61,6 +68,37 @@ async def get_pending_jobs(
         .with_for_update(skip_locked=True)
     )
     return list(result.scalars().all())
+
+
+async def reclaim_orphan_jobs(
+    db: AsyncSession, threshold: timedelta = ORPHAN_RECLAIM_THRESHOLD
+) -> int:
+    """processing のまま放置された孤児ジョブを pending に戻す。
+
+    worker がクラッシュ/再起動したときに status='processing' のまま残されたジョブを
+    回収する。attempts は保持するので、次回実行時のバックオフは引き続き有効。
+
+    Returns:
+        回収したジョブ数
+    """
+    cutoff = datetime.now(timezone.utc) - threshold
+    result = await db.execute(
+        update(DeliveryJob)
+        .where(
+            DeliveryJob.status == "processing",
+            DeliveryJob.last_attempted_at < cutoff,
+        )
+        .values(status="pending")
+    )
+    await db.commit()
+    count = result.rowcount or 0
+    if count > 0:
+        logger.warning(
+            "Reclaimed %d orphan processing jobs (older than %s)",
+            count,
+            threshold,
+        )
+    return count
 
 
 async def get_next_jobs(db: AsyncSession, limit: int = 20) -> list[DeliveryJob]:
@@ -230,12 +268,30 @@ async def run_delivery_loop():
     """並行ジョブ処理を行うメイン配送ワーカーループ。"""
     logger.info("Delivery worker started (max_concurrent=%d)", MAX_CONCURRENT)
 
+    # 起動時: 前回の worker がクラッシュ/強制停止した際に processing のまま残したジョブを回収。
+    try:
+        async with async_session() as db:
+            await reclaim_orphan_jobs(db)
+    except Exception:
+        logger.exception("Startup orphan reclamation failed")
+
     sem = asyncio.Semaphore(MAX_CONCURRENT)
     tasks: set[asyncio.Task] = set()
+    last_reclaim_at = datetime.now(timezone.utc)
 
     while True:
         try:
             await _update_heartbeat()
+
+            # 定期的に孤児ジョブを回収 (ループ実行中に他インスタンスがクラッシュした場合の保険)。
+            now = datetime.now(timezone.utc)
+            if now - last_reclaim_at >= ORPHAN_RECLAIM_INTERVAL:
+                try:
+                    async with async_session() as db:
+                        await reclaim_orphan_jobs(db)
+                except Exception:
+                    logger.exception("Periodic orphan reclamation failed")
+                last_reclaim_at = now
 
             had_work = False
             async with async_session() as db:

--- a/backend/tests/test_delivery_worker.py
+++ b/backend/tests/test_delivery_worker.py
@@ -9,10 +9,12 @@ import pytest
 
 from app.models.delivery import DeliveryJob
 from app.worker.delivery_worker import (
+    ORPHAN_RECLAIM_THRESHOLD,
     _deliver_one,
     deliver_activity,
     get_actor_with_key,
     get_pending_jobs,
+    reclaim_orphan_jobs,
 )
 from tests.conftest import make_remote_actor
 
@@ -480,3 +482,84 @@ async def test_deliver_one_skips_non_processing_job(db, pending_job, mock_valkey
 
     # Job should remain in pending state, untouched
     assert pending_job.status == "pending"
+
+
+# ── reclaim_orphan_jobs ──
+
+
+async def test_reclaim_orphan_jobs_recovers_old_processing(db, test_user, mock_valkey):
+    old_job = DeliveryJob(
+        actor_id=test_user.actor_id,
+        target_inbox_url="http://remote.example/inbox",
+        payload={"type": "Create"},
+        status="processing",
+        attempts=3,
+        last_attempted_at=datetime.now(timezone.utc) - ORPHAN_RECLAIM_THRESHOLD - timedelta(
+            minutes=5
+        ),
+    )
+    db.add(old_job)
+    await db.flush()
+
+    count = await reclaim_orphan_jobs(db)
+
+    assert count == 1
+    await db.refresh(old_job)
+    assert old_job.status == "pending"
+    # attempts は保持されるべき (次回バックオフが引き続き効く)
+    assert old_job.attempts == 3
+
+
+async def test_reclaim_orphan_jobs_leaves_fresh_processing(db, test_user, mock_valkey):
+    fresh_job = DeliveryJob(
+        actor_id=test_user.actor_id,
+        target_inbox_url="http://remote.example/inbox",
+        payload={"type": "Create"},
+        status="processing",
+        attempts=1,
+        last_attempted_at=datetime.now(timezone.utc) - timedelta(seconds=30),
+    )
+    db.add(fresh_job)
+    await db.flush()
+
+    count = await reclaim_orphan_jobs(db)
+
+    assert count == 0
+    await db.refresh(fresh_job)
+    assert fresh_job.status == "processing"
+
+
+async def test_reclaim_orphan_jobs_ignores_other_statuses(db, test_user, mock_valkey):
+    old_ts = datetime.now(timezone.utc) - ORPHAN_RECLAIM_THRESHOLD - timedelta(hours=1)
+    pending = DeliveryJob(
+        actor_id=test_user.actor_id,
+        target_inbox_url="http://remote.example/inbox",
+        payload={"type": "Create"},
+        status="pending",
+        last_attempted_at=old_ts,
+    )
+    delivered = DeliveryJob(
+        actor_id=test_user.actor_id,
+        target_inbox_url="http://remote.example/inbox",
+        payload={"type": "Create"},
+        status="delivered",
+        last_attempted_at=old_ts,
+    )
+    dead = DeliveryJob(
+        actor_id=test_user.actor_id,
+        target_inbox_url="http://remote.example/inbox",
+        payload={"type": "Create"},
+        status="dead",
+        last_attempted_at=old_ts,
+    )
+    db.add_all([pending, delivered, dead])
+    await db.flush()
+
+    count = await reclaim_orphan_jobs(db)
+
+    assert count == 0
+    for job in (pending, delivered, dead):
+        await db.refresh(job)
+    assert pending.status == "pending"
+    assert delivered.status == "delivered"
+    assert dead.status == "dead"


### PR DESCRIPTION
## 概要

worker がクラッシュ/再起動したとき、\`status='processing'\` のまま残されたジョブを自動回収するリース回収処理を追加する。

Closes #992

## 現状の問題

本番で \`last_attempted_at\` が 28〜29 日前の processing ジョブが 15 件確認されている。worker 起動時のリース回収処理が欠けていたため、これらのジョブは永久に配送されず放置される。

\`\`\`
SELECT id, host, last_attempted_at, now() - last_attempted_at AS stuck_for
FROM delivery_queue WHERE status='processing' ORDER BY last_attempted_at LIMIT 5;
→ 全件 2026-03-24 前後で止まっている
\`\`\`

## 変更内容

- **\`reclaim_orphan_jobs()\`** 関数を追加: \`status='processing'\` かつ \`last_attempted_at < now() - threshold\` のジョブを一括で pending に戻す
- **起動時に 1 回実行**: 前回の worker が取りこぼしたジョブを即座に回収
- **1 分毎に定期実行**: ループ実行中に他インスタンスがクラッシュした場合の保険
- **閾値**: 10 分（配送タイムアウト 30s + 処理時間を大きく上回る値）
- **attempts カウントは保持**: 回収後も指数バックオフは引き続き機能する

## Test plan

- [x] 新規テスト 3 件追加（古い processing → pending、新しい processing 据え置き、他ステータス無視）
- [x] 既存 26 テスト + 新規 3 テスト、計 29 件すべてパス
- [x] \`ruff check\` クリア

## デプロイ後の確認

デプロイ後、本番で以下を実行して 15 件が pending に戻ったことを確認する:

\`\`\`sql
SELECT status, count(*) FROM delivery_queue GROUP BY status;
\`\`\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
