### PR TITLE
perf: Mastodon API の N+1 クエリを解消 (#989, #990)

### DIFF
--- a/backend/app/api/mastodon/accounts.py
+++ b/backend/app/api/mastodon/accounts.py
@@ -867,8 +867,15 @@ async def list_blocks(
         return []
 
     result = await db.execute(select(Actor).where(Actor.id.in_(blocked_ids)))
-    actors = result.scalars().all()
-    return [await _actor_to_account(a, db=db) for a in actors]
+    actors = list(result.scalars().all())
+    emoji_map = await _batch_resolve_actor_emojis(db, actors)
+    results = []
+    for a in actors:
+        account = await _actor_to_account(a)
+        if a.id in emoji_map:
+            account["emojis"] = emoji_map[a.id]
+        results.append(account)
+    return results
 
 
 @relationships_router.get("/mutes")
@@ -883,5 +890,12 @@ async def list_mutes(
         return []
 
     result = await db.execute(select(Actor).where(Actor.id.in_(muted_ids)))
-    actors = result.scalars().all()
-    return [await _actor_to_account(a, db=db) for a in actors]
+    actors = list(result.scalars().all())
+    emoji_map = await _batch_resolve_actor_emojis(db, actors)
+    results = []
+    for a in actors:
+        account = await _actor_to_account(a)
+        if a.id in emoji_map:
+            account["emojis"] = emoji_map[a.id]
+        results.append(account)
+    return results

--- a/backend/app/api/mastodon/lists.py
+++ b/backend/app/api/mastodon/lists.py
@@ -121,6 +121,17 @@ async def delete_list_endpoint(
     return {}
 
 
+def _parse_account_ids(account_ids: list[str]) -> list[uuid.UUID]:
+    """account_ids の UUID パース。不正があれば 422 を返す (L-1)。"""
+    parsed: list[uuid.UUID] = []
+    for account_id in account_ids:
+        try:
+            parsed.append(uuid.UUID(account_id))
+        except (ValueError, AttributeError):
+            raise HTTPException(status_code=422, detail=f"Invalid account ID: {account_id}")
+    return parsed
+
+
 @router.get("/{list_id}/accounts")
 async def get_list_accounts(
     list_id: uuid.UUID,
@@ -130,7 +141,7 @@ async def get_list_accounts(
     lst = await _get_owned_list(db, list_id, user)
     from sqlalchemy import select as sel
 
-    from app.api.mastodon.accounts import _actor_to_account
+    from app.api.mastodon.accounts import _actor_to_account, _batch_resolve_actor_emojis
     from app.models.actor import Actor
     from app.models.list import ListMember
 
@@ -139,8 +150,15 @@ async def get_list_accounts(
         .join(ListMember, ListMember.actor_id == Actor.id)
         .where(ListMember.list_id == lst.id)
     )
-    actors = result.scalars().all()
-    return [await _actor_to_account(a, db=db) for a in actors]
+    actors = list(result.scalars().all())
+    emoji_map = await _batch_resolve_actor_emojis(db, actors)
+    results = []
+    for a in actors:
+        account = await _actor_to_account(a)
+        if a.id in emoji_map:
+            account["emojis"] = emoji_map[a.id]
+        results.append(account)
+    return results
 
 
 @router.post(
@@ -158,17 +176,10 @@ async def add_list_accounts(
 
     from app.models.actor import Actor
 
-    # L-1: 不正UUIDに対して422エラーを返す
-    for account_id in body.account_ids:
-        try:
-            uuid.UUID(account_id)
-        except (ValueError, AttributeError):
-            raise HTTPException(status_code=422, detail=f"Invalid account ID: {account_id}")
-    for account_id in body.account_ids:
-        aid = uuid.UUID(account_id)
-        result = await db.execute(sel(Actor).where(Actor.id == aid))
-        actor = result.scalar_one_or_none()
-        if actor:
+    parsed_ids = _parse_account_ids(body.account_ids)
+    if parsed_ids:
+        result = await db.execute(sel(Actor).where(Actor.id.in_(parsed_ids)))
+        for actor in result.scalars().all():
             await add_list_member(db, lst, actor)
     await db.commit()
     return {}
@@ -189,17 +200,10 @@ async def remove_list_accounts(
 
     from app.models.actor import Actor
 
-    # L-1: 不正UUIDに対して422エラーを返す
-    for account_id in body.account_ids:
-        try:
-            uuid.UUID(account_id)
-        except (ValueError, AttributeError):
-            raise HTTPException(status_code=422, detail=f"Invalid account ID: {account_id}")
-    for account_id in body.account_ids:
-        aid = uuid.UUID(account_id)
-        result = await db.execute(sel(Actor).where(Actor.id == aid))
-        actor = result.scalar_one_or_none()
-        if actor:
+    parsed_ids = _parse_account_ids(body.account_ids)
+    if parsed_ids:
+        result = await db.execute(sel(Actor).where(Actor.id.in_(parsed_ids)))
+        for actor in result.scalars().all():
             await remove_list_member(db, lst, actor)
     await db.commit()
     return {}


### PR DESCRIPTION
## 概要

Mastodon 互換 API の残存 N+1 を 2 か所解消する。

Closes #989
Closes #990

## 変更内容

### #989 リスト API (\`lists.py\`)

- **\`add_list_accounts\` / \`remove_list_accounts\`**: account_ids のループ内 \`SELECT Actor WHERE id = aid\` を \`Actor.id.in_()\` で一括取得に変更
- **\`get_list_accounts\`**: \`_actor_to_account(a, db=db)\` の N 回呼び出しを \`_batch_resolve_actor_emojis\` + \`_actor_to_account(a)\` に変更（\`/followers\`, \`/following\` と同じパターン）
- UUID パースを \`_parse_account_ids\` ヘルパーに集約

### #990 アカウント API (\`accounts.py\`)

- **\`list_blocks\` / \`list_mutes\`**: 絵文字解決を \`_batch_resolve_actor_emojis\` で一括化（\`/followers\`, \`/following\` と同じパターン）

## 効果

リスト一括追加 / 一括ブロック表示等で、アカウント数に比例して増えていたクエリ数が定数オーダー（2〜3 クエリ）に削減される。

## Test plan

- [x] \`tests/test_api_lists.py\`, \`tests/test_list_service.py\`, \`tests/test_blocks_mutes_bookmarks.py\`, \`tests/test_block_service_extended.py\`, \`tests/test_mute_service.py\` 計 94 件すべてパス
- [x] \`ruff check\` クリア
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
