### PR TITLE
perf: ストリーミング publish を Valkey pipeline で一括化 (#991)

### DIFF
--- a/backend/app/activitypub/handlers/announce.py
+++ b/backend/app/activitypub/handlers/announce.py
@@ -173,10 +173,14 @@ async def handle_announce(db: AsyncSession, activity: dict):
         from app.valkey_client import valkey as valkey_client
 
         event = json.dumps({"event": "update", "payload": {"id": str(note.id)}})
-        if visibility == "public":
-            await valkey_client.publish("timeline:public", event)
         follower_ids = await get_follower_ids(db, actor.id)
+
+        # 大量フォロワーでも 1 往復で済むよう pipeline で一括 publish。
+        pipe = valkey_client.pipeline()
+        if visibility == "public":
+            pipe.publish("timeline:public", event)
         for fid in follower_ids:
-            await valkey_client.publish(f"timeline:home:{fid}", event)
+            pipe.publish(f"timeline:home:{fid}", event)
+        await pipe.execute()
     except Exception:
         logger.debug("Failed to publish Announce streaming event", exc_info=True)

--- a/backend/app/activitypub/handlers/create.py
+++ b/backend/app/activitypub/handlers/create.py
@@ -402,8 +402,6 @@ async def handle_create_note(db: AsyncSession, activity: dict, note_data: dict):
         from app.valkey_client import valkey as valkey_client
 
         event = json.dumps({"event": "update", "payload": {"id": str(note.id)}})
-        if visibility == "public":
-            await valkey_client.publish("timeline:public", event)
         # このリモートアクターのフォロワー (フォローしているローカルユーザー) に配信
         # システムアカウントのアクターIDを除外
         from app.services.proxy_service import get_system_actor_ids
@@ -419,14 +417,17 @@ async def handle_create_note(db: AsyncSession, activity: dict, note_data: dict):
         )
 
         exclusive_user_ids = await get_exclusive_list_user_actor_ids(db, actor.id)
+        list_ids = await get_list_ids_for_actor(db, actor.id)
+
+        pipe = valkey_client.pipeline()
+        if visibility == "public":
+            pipe.publish("timeline:public", event)
         for fid in follower_ids:
             if fid not in system_ids and fid not in exclusive_user_ids:
-                await valkey_client.publish(f"timeline:home:{fid}", event)
-
-        # リストタイムラインチャンネルに配信
-        list_ids = await get_list_ids_for_actor(db, actor.id)
+                pipe.publish(f"timeline:home:{fid}", event)
         for lid in list_ids:
-            await valkey_client.publish(f"timeline:list:{lid}", event)
+            pipe.publish(f"timeline:list:{lid}", event)
+        await pipe.execute()
     except Exception:
         logger.exception("Failed to publish remote note to streaming")
 

--- a/backend/app/api/mastodon/statuses.py
+++ b/backend/app/api/mastodon/statuses.py
@@ -1520,12 +1520,15 @@ async def reblog_status(
         from app.valkey_client import valkey as valkey_client
 
         event = _json.dumps({"event": "update", "payload": {"id": str(reblog_note.id)}})
-        if reblog_vis == "public":
-            await valkey_client.publish("timeline:public", event)
         follower_ids = await get_follower_ids(db, actor.id)
+
+        pipe = valkey_client.pipeline()
+        if reblog_vis == "public":
+            pipe.publish("timeline:public", event)
         for fid in follower_ids:
-            await valkey_client.publish(f"timeline:home:{fid}", event)
-        await valkey_client.publish(f"timeline:home:{actor.id}", event)
+            pipe.publish(f"timeline:home:{fid}", event)
+        pipe.publish(f"timeline:home:{actor.id}", event)
+        await pipe.execute()
     except Exception:
         pass  # pub/sub の失敗でリブログを失敗させない
 

--- a/backend/app/services/reaction_service.py
+++ b/backend/app/services/reaction_service.py
@@ -26,14 +26,15 @@ async def _publish_reaction_event(db: AsyncSession, note: Note) -> None:
             }
         )
 
-        if note.visibility == "public":
-            await valkey_client.publish("timeline:public", event)
-
-        await valkey_client.publish(f"timeline:home:{note.actor_id}", event)
-
         follower_ids = await get_follower_ids(db, note.actor_id)
+
+        pipe = valkey_client.pipeline()
+        if note.visibility == "public":
+            pipe.publish("timeline:public", event)
+        pipe.publish(f"timeline:home:{note.actor_id}", event)
         for fid in follower_ids:
-            await valkey_client.publish(f"timeline:home:{fid}", event)
+            pipe.publish(f"timeline:home:{fid}", event)
+        await pipe.execute()
     except Exception:
         pass
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from collections.abc import AsyncGenerator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import sqlalchemy as sa
@@ -159,10 +159,12 @@ def mock_valkey():
     mock.scan = AsyncMock(return_value=(0, []))
     mock.mget = AsyncMock(side_effect=lambda keys: [None] * len(keys))
 
-    # pipeline mock: set/execute をサポート
+    # pipeline mock: 呼び出しは mock.publish / mock.set に集約して call_args_list で
+    # 直接呼び出しと pipeline 経由を同じ視点から観察できるようにする。
     def _make_pipeline():
         pipe = AsyncMock()
-        pipe.set = MagicMock(return_value=pipe)
+        pipe.set = mock.set
+        pipe.publish = mock.publish
         pipe.execute = AsyncMock(return_value=[])
         return pipe
 


### PR DESCRIPTION
## 概要

大量フォロワーを持つアクターのノート/リノート/リアクション通知が、フォロワー数に比例して Valkey RTT を線形に積み重ねていたのを **1 往復** に削減する。

Closes #991

## 該当箇所

Issue #991 で挙げた announce.py に加え、同パターンを持つ以下 3 箇所も横展開:

| ファイル | 処理 |
|---|---|
| \`activitypub/handlers/announce.py\` | リモート Announce 受信時 |
| \`activitypub/handlers/create.py\` | リモート Note 受信時 |
| \`api/mastodon/statuses.py\` | ローカル Reblog 投稿時 |
| \`services/reaction_service.py\` | リアクション通知 |

既存の \`note_service.py\` (local Create) は pipeline 化済みのため、そのパターンを踏襲した。

## 変更の肝

\`\`\`python
# before: フォロワー数分の Valkey 往復
for fid in follower_ids:
    await valkey_client.publish(f\"timeline:home:{fid}\", event)

# after: pipeline で 1 往復にまとめる
pipe = valkey_client.pipeline()
if visibility == \"public\":
    pipe.publish(\"timeline:public\", event)
for fid in follower_ids:
    pipe.publish(f\"timeline:home:{fid}\", event)
await pipe.execute()
\`\`\`

## テスト更新

\`tests/conftest.py\` の \`mock_valkey.pipeline\` を更新: \`pipe.publish\` を \`mock.publish\` と共有することで、直接 publish と pipeline 経由の \`call_args_list\` を同じ視点で観察できるようにした (既存テストの互換性維持のため)。

## Test plan

- [x] \`test_reaction_streaming.py\` / \`test_handler_announce.py\` / \`test_handler_create.py\` / \`test_reaction_service.py\` / \`test_service_reaction.py\` / \`test_fedibird_reactions.py\` 計 58 件パス
- [x] \`ruff check\` クリア (既存の E402 等は pre-existing)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
