### PR TITLE
fix: moved フィールドが /blocks, /mutes, リストで解決されない問題を修正 (#999)

### DIFF
--- a/backend/app/api/mastodon/accounts.py
+++ b/backend/app/api/mastodon/accounts.py
@@ -180,7 +180,16 @@ async def _actor_to_account(
     following_count: int | None = None,
     statuses_count: int | None = None,
     db: AsyncSession | None = None,
+    resolve_emojis: bool = True,
 ) -> dict:
+    """Actor を Mastodon 互換 account dict に変換する。
+
+    Args:
+        resolve_emojis: False を指定すると絵文字解決の per-actor クエリをスキップする。
+            呼び出し側で ``_batch_resolve_actor_emojis`` により一括解決済みの場合に
+            指定する。``moved`` フィールドの解決には影響しない (``db`` が渡されていれば
+            引き続き行われる)。
+    """
     import re
 
     avatar = (
@@ -218,7 +227,7 @@ async def _actor_to_account(
     }
 
     # display_name、summary、fields からカスタム絵文字を解決
-    if db:
+    if db and resolve_emojis:
         shortcode_re = re.compile(r":([a-zA-Z0-9_]+):")
         texts = [data["display_name"] or "", data["note"]]
         for f in actor.fields or []:
@@ -594,7 +603,8 @@ async def list_followers(
     emoji_map = await _batch_resolve_actor_emojis(db, actors)
     results = []
     for a in actors:
-        account = await _actor_to_account(a)
+        # db は moved フィールド解決のために渡す。絵文字は emoji_map で差し込む。
+        account = await _actor_to_account(a, db=db, resolve_emojis=False)
         if a.id in emoji_map:
             account["emojis"] = emoji_map[a.id]
         results.append(account)
@@ -618,7 +628,7 @@ async def list_following(
     emoji_map = await _batch_resolve_actor_emojis(db, actors)
     results = []
     for a in actors:
-        account = await _actor_to_account(a)
+        account = await _actor_to_account(a, db=db, resolve_emojis=False)
         if a.id in emoji_map:
             account["emojis"] = emoji_map[a.id]
         results.append(account)
@@ -871,7 +881,7 @@ async def list_blocks(
     emoji_map = await _batch_resolve_actor_emojis(db, actors)
     results = []
     for a in actors:
-        account = await _actor_to_account(a)
+        account = await _actor_to_account(a, db=db, resolve_emojis=False)
         if a.id in emoji_map:
             account["emojis"] = emoji_map[a.id]
         results.append(account)
@@ -894,7 +904,7 @@ async def list_mutes(
     emoji_map = await _batch_resolve_actor_emojis(db, actors)
     results = []
     for a in actors:
-        account = await _actor_to_account(a)
+        account = await _actor_to_account(a, db=db, resolve_emojis=False)
         if a.id in emoji_map:
             account["emojis"] = emoji_map[a.id]
         results.append(account)

--- a/backend/app/api/mastodon/lists.py
+++ b/backend/app/api/mastodon/lists.py
@@ -154,7 +154,7 @@ async def get_list_accounts(
     emoji_map = await _batch_resolve_actor_emojis(db, actors)
     results = []
     for a in actors:
-        account = await _actor_to_account(a)
+        account = await _actor_to_account(a, db=db, resolve_emojis=False)
         if a.id in emoji_map:
             account["emojis"] = emoji_map[a.id]
         results.append(account)

--- a/backend/tests/test_blocks_mutes_bookmarks.py
+++ b/backend/tests/test_blocks_mutes_bookmarks.py
@@ -230,6 +230,50 @@ async def test_list_mutes_api(db, app_client, mock_valkey, test_user, test_user_
     assert any(a["username"] == "testuser_b" for a in data)
 
 
+# Regression: PR #997 で _actor_to_account(a, db=db) を _actor_to_account(a) に変更した際に
+# moved フィールドの解決が一緒に止まっていた。#999 で resolve_emojis=False による
+# バッチ絵文字との両立を入れた後の検証。
+async def test_list_blocks_includes_moved_field(
+    db, app_client, mock_valkey, test_user
+):
+    """ブロックした相手が移行済みなら moved フィールドが返る。"""
+    # 移行先アクター
+    target = await make_remote_actor(db, username="alice_new", domain="new.example")
+    # 移行元アクター (moved_to_ap_id を target に)
+    source = await make_remote_actor(db, username="alice_old", domain="old.example")
+    source.moved_to_ap_id = target.ap_id
+    await db.commit()
+
+    client = authed_client_for(app_client, mock_valkey, test_user)
+    await client.post(f"/api/v1/accounts/{source.id}/block")
+
+    resp = await client.get("/api/v1/blocks")
+    assert resp.status_code == 200
+    data = resp.json()
+    entry = next(a for a in data if a["username"] == "alice_old")
+    assert "moved" in entry, "moved field must be resolved"
+    assert entry["moved"]["username"] == "alice_new"
+
+
+async def test_list_mutes_includes_moved_field(
+    db, app_client, mock_valkey, test_user
+):
+    target = await make_remote_actor(db, username="bob_new", domain="new.example")
+    source = await make_remote_actor(db, username="bob_old", domain="old.example")
+    source.moved_to_ap_id = target.ap_id
+    await db.commit()
+
+    client = authed_client_for(app_client, mock_valkey, test_user)
+    await client.post(f"/api/v1/accounts/{source.id}/mute")
+
+    resp = await client.get("/api/v1/mutes")
+    assert resp.status_code == 200
+    data = resp.json()
+    entry = next(a for a in data if a["username"] == "bob_old")
+    assert "moved" in entry
+    assert entry["moved"]["username"] == "bob_new"
+
+
 # ── Bookmark Service ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## 概要

PR #997 のバッチ化で \`_actor_to_account(a, db=db)\` を \`_actor_to_account(a)\` に変更した際、内部の「移行先アカウント解決」処理 (accounts.py L252-261) が \`db=None\` のためスキップされるようになっていた。Devin Review が検出。

Closes #999

## 影響範囲

- \`GET /api/v1/blocks\` (PR #997 で導入された regression)
- \`GET /api/v1/mutes\` (PR #997 で導入された regression)
- \`GET /api/v1/lists/{list_id}/accounts\` (PR #997 で導入された regression)
- \`GET /api/v1/accounts/{id}/followers\` (PR #997 以前からの pre-existing)
- \`GET /api/v1/accounts/{id}/following\` (PR #997 以前からの pre-existing)

移行済みアクターを含むレスポンスで \`moved\` フィールドが返らないため、クライアントの移行バナー表示・新アカウントへのリダイレクトが機能しなかった。

## アプローチ

\`_actor_to_account\` に \`resolve_emojis: bool = True\` パラメータを追加:

\`\`\`python
async def _actor_to_account(
    actor: Actor,
    ...,
    db: AsyncSession | None = None,
    resolve_emojis: bool = True,
) -> dict:
    ...
    # 絵文字解決は resolve_emojis=True のときだけ
    if db and resolve_emojis:
        ...
    # moved 解決は db さえあれば行う
    if getattr(actor, \"moved_to_ap_id\", None) and db:
        ...
\`\`\`

バッチ絵文字解決を使う 5 エンドポイント側では \`_actor_to_account(a, db=db, resolve_emojis=False)\` を渡す。

- \`db\` が渡るので moved 解決は動く
- \`resolve_emojis=False\` で per-actor の絵文字 DB クエリはスキップ (バッチ経路が担う)

## Test plan

- [x] 新規テスト 2 件追加: \`/blocks\` と \`/mutes\` で移行済みアクターの \`moved\` フィールドが返ることを検証
- [x] \`tests/test_api_lists.py\` / \`tests/test_blocks_mutes_bookmarks.py\` / \`tests/test_account_migration.py\` / \`tests/test_actor_service_extended.py\` 計 98 件パス
- [x] \`ruff check\` 対象範囲はクリア (\`tests/test_blocks_mutes_bookmarks.py\` の既存 I001/E501 は pre-existing)

## PR #998 との関係

PR #998 は本修正とは別経路 (streaming pipeline) なので独立。本 PR のマージ後、#998 を develop に rebase する。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/1000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
