### PR TITLE
Release 20260423-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [20260423-2](https://github.com/nekonoverse/nekonoverse/releases/tag/20260423-2) — 2026-04-23
+
+### パフォーマンス
+
+- **`delivery_queue` の bloat 対策** — delivered 済み配送ジョブを 1 時間ごとに自動 purge するワーカーを追加し、`delivery_queue` の autovacuum を攻めた設定 (`scale_factor=0.05`) に変更。本番で `dead_ratio` が 0.03 → 0.19 まで悪化していた根本原因だった `purge_delivered` の定期未実行と UPDATE-heavy テーブルのデフォルト autovacuum を同時に解消 (#1002, #1003)
+
+### 運用メモ
+
+- 初回アップグレード時は `quickstart.md` 記載の `DELETE ... + VACUUM FULL delivery_queue` を一度だけ手動実行して既存の bloat を解消する必要がある (テーブルロック発生のため深夜帯推奨)
+
+---
+
 ## [20260423-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260423-1) — 2026-04-23
 
 ### バグ修正

--- a/backend/alembic/versions/042_tune_delivery_queue_autovacuum.py
+++ b/backend/alembic/versions/042_tune_delivery_queue_autovacuum.py
@@ -1,0 +1,33 @@
+"""delivery_queue の autovacuum を攻める設定に変更。
+
+delivery_queue は status 遷移 (pending→processing→delivered/dead) と
+next_retry_at 更新で UPDATE が多い。デフォルトの vacuum_scale_factor=0.2 だと
+30k 行で 6k 行の dead tuple が溜まるまで起動せず bloat が進行する。
+5% まで下げて遅延を小さくする。
+
+Revision ID: 042
+Revises: 041
+"""
+
+from alembic import op
+
+revision = "042"
+down_revision = "041"
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE delivery_queue SET ("
+        "autovacuum_vacuum_scale_factor = 0.05, "
+        "autovacuum_analyze_scale_factor = 0.05"
+        ")"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE delivery_queue RESET ("
+        "autovacuum_vacuum_scale_factor, "
+        "autovacuum_analyze_scale_factor"
+        ")"
+    )

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260423-1"
+__version__ = "20260423-2"
 
 
 def _resolve_version() -> str:

--- a/backend/app/worker/delivery_purge_worker.py
+++ b/backend/app/worker/delivery_purge_worker.py
@@ -1,0 +1,48 @@
+"""delivered 済み配送ジョブの定期パージ。
+
+delivery_queue テーブルは UPDATE-heavy なため、配送完了後の行を溜め込むと
+bloat が進行して autovacuum 追従コストも上がる。1 時間ごとに 24 時間より古い
+delivered ジョブを削除する。dead / pending には触らない（retry 用途で保持）。
+"""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+CHECK_INTERVAL = 3600  # 1 時間
+PURGE_OLDER_THAN_HOURS = 24
+HEARTBEAT_KEY = "worker:delivery_purge:heartbeat"
+
+
+async def _run_once() -> int:
+    """1 回分のパージ処理を実行する。テスト容易性のため切り出し。"""
+    # lazy import でテスト時の mock_valkey パッチが効くようにする。
+    from app.database import async_session
+    from app.services.queue_service import purge_delivered
+    from app.valkey_client import valkey
+
+    await valkey.set(HEARTBEAT_KEY, "alive", ex=CHECK_INTERVAL * 3)
+
+    async with async_session() as db:
+        count = await purge_delivered(db, older_than_hours=PURGE_OLDER_THAN_HOURS)
+    if count:
+        logger.info("Purged %d delivered delivery jobs", count)
+    return count
+
+
+async def run_delivery_purge_loop() -> None:
+    """delivered ジョブを 1 時間ごとにパージする。"""
+    logger.info(
+        "Delivery purge worker started (interval=%ds, older_than=%dh)",
+        CHECK_INTERVAL,
+        PURGE_OLDER_THAN_HOURS,
+    )
+
+    while True:
+        try:
+            await _run_once()
+        except Exception:
+            logger.exception("Error in delivery purge loop")
+
+        await asyncio.sleep(CHECK_INTERVAL)

--- a/backend/app/worker/main.py
+++ b/backend/app/worker/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 
+from app.worker.delivery_purge_worker import run_delivery_purge_loop
 from app.worker.delivery_worker import run_delivery_loop
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(levelname)s: %(message)s")
@@ -21,6 +22,7 @@ async def run_worker():
 
     await asyncio.gather(
         run_delivery_loop(),
+        run_delivery_purge_loop(),
         run_face_detect_loop(),
         run_summary_proxy_loop(),
         run_email_loop(),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260423-1"
+version = "20260423-2"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_delivery_purge_worker.py
+++ b/backend/tests/test_delivery_purge_worker.py
@@ -1,0 +1,73 @@
+"""delivery_purge_worker の動作テスト。"""
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from app.models.delivery import DeliveryJob
+from app.worker.delivery_purge_worker import HEARTBEAT_KEY, _run_once
+
+
+def _patch_async_session(db):
+    """`async_session()` を指定したテスト用 session に差し替える context manager。"""
+
+    @asynccontextmanager
+    async def fake_session():
+        yield db
+
+    return patch("app.database.async_session", fake_session)
+
+
+async def test_run_once_deletes_old_delivered(db, mock_valkey, test_user):
+    """24h より古い delivered ジョブが削除されること。"""
+    old = DeliveryJob(
+        actor_id=test_user.actor_id,
+        target_inbox_url="https://remote.example/inbox",
+        payload={"type": "Create"},
+        status="delivered",
+        created_at=datetime.now(timezone.utc) - timedelta(hours=48),
+    )
+    recent = DeliveryJob(
+        actor_id=test_user.actor_id,
+        target_inbox_url="https://remote.example/inbox",
+        payload={"type": "Create"},
+        status="delivered",
+        created_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    db.add_all([old, recent])
+    await db.flush()
+
+    with _patch_async_session(db):
+        count = await _run_once()
+    assert count == 1
+
+
+async def test_run_once_does_not_touch_dead_or_pending(db, mock_valkey, test_user):
+    """dead / pending は purge 対象外 (retry 用途で保持)。"""
+    dead = DeliveryJob(
+        actor_id=test_user.actor_id,
+        target_inbox_url="https://remote.example/inbox",
+        payload={"type": "Create"},
+        status="dead",
+        created_at=datetime.now(timezone.utc) - timedelta(hours=48),
+    )
+    pending = DeliveryJob(
+        actor_id=test_user.actor_id,
+        target_inbox_url="https://remote.example/inbox",
+        payload={"type": "Create"},
+        status="pending",
+        created_at=datetime.now(timezone.utc) - timedelta(hours=48),
+    )
+    db.add_all([dead, pending])
+    await db.flush()
+
+    with _patch_async_session(db):
+        count = await _run_once()
+    assert count == 0
+
+
+async def test_run_once_updates_heartbeat(db, mock_valkey):
+    """heartbeat が更新されること。"""
+    with _patch_async_session(db):
+        await _run_once()
+    mock_valkey.set.assert_any_call(HEARTBEAT_KEY, "alive", ex=3600 * 3)

--- a/backend/tests/test_worker_main.py
+++ b/backend/tests/test_worker_main.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 async def test_run_worker_calls_delivery_loop():
     with (
         patch("app.worker.main.run_delivery_loop", new_callable=AsyncMock) as mock_loop,
+        patch("app.worker.main.run_delivery_purge_loop", new_callable=AsyncMock),
         patch("app.services.face_detect_queue.run_face_detect_loop", new_callable=AsyncMock),
         patch("app.services.summary_proxy_queue.run_summary_proxy_loop", new_callable=AsyncMock),
         patch("app.services.email_queue.run_email_loop", new_callable=AsyncMock),

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -123,6 +123,26 @@ docker compose restart nginx
 !!! note "UDS 構成と TCP 構成"
     `docker-compose.prod.yml` では全サービス間通信を Unix Domain Socket で行うため、コンテナ再作成時に nginx の再起動が不要。TCP 構成 (`docker-compose.yml`) では内部 IP が変わるため `restart nginx` が必要。
 
+### migration 042 適用時の delivery_queue bloat 解消 (一度だけ)
+
+migration 042 適用後は定期 purge ワーカーが 1 時間ごとに 24h 超の `delivered` 行を削除し、`delivery_queue` の autovacuum も攻めた設定 (`scale_factor=0.05`) に変わります。ただし既存の bloat は手動で `VACUUM FULL` する必要があります（初回適用時のみ）。
+
+```bash
+# 現状確認: dead_ratio が 0.1 を超えていたら実施推奨
+docker compose exec postgresql psql -U nekonoverse -d nekonoverse -c "
+SELECT pg_size_pretty(pg_total_relation_size('delivery_queue')) AS size,
+       n_dead_tup::float / NULLIF(n_live_tup,0) AS dead_ratio,
+       n_live_tup AS live_rows
+FROM pg_stat_user_tables WHERE relname='delivery_queue';
+"
+
+# 既存の delivered を purge してから VACUUM FULL（テーブルロックが走るので深夜帯推奨）
+docker compose exec postgresql psql -U nekonoverse -d nekonoverse -c "
+DELETE FROM delivery_queue WHERE status='delivered' AND created_at < now() - interval '24 hours';
+VACUUM FULL delivery_queue;
+"
+```
+
 ### Docker イメージタグ
 
 | タグ | 内容 | 用途 |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260423-1",
+  "version": "20260423-2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- `delivery_queue` の bloat 対策: 定期 purge ワーカー + autovacuum チューニング (#1002, #1003)

## 運用メモ

初回アップグレード時は `quickstart.md` 記載の `DELETE ... + VACUUM FULL delivery_queue` を一度だけ手動実行して既存の bloat を解消する必要がある（テーブルロック発生のため深夜帯推奨）。

## Test plan

- [x] backend-test, e2e-test, federation-test, mastodon-client-test すべて pass (PR #1003 で確認済み)
- [x] Devin Review クリーン
- [ ] Web UI でマージ
- [ ] タグ push → develop に同期 → GitHub Release 作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/1004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
