### PR TITLE
fix: /api/v1/instance の stats が常に 0 を返すバグ (#1006)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -233,7 +233,7 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
     except Exception:
         pass
 
-    from sqlalchemy import func, literal_column, select
+    from sqlalchemy import func, select
 
     from app.models.actor import Actor
     from app.models.note import Note
@@ -310,7 +310,7 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
                 user_sq.label("users"),
                 status_sq.label("statuses"),
                 domain_sq.label("domains"),
-            ).select_from(literal_column("(SELECT 1) AS _dummy"))
+            )
         )
         stats_row = stats_result.one()
         user_count = stats_row.users or 0

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -317,7 +317,8 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
         status_count = stats_row.statuses or 0
         domain_count = stats_row.domains or 0
     except Exception:
-        pass
+        import logging
+        logging.getLogger(__name__).exception("instance v1 stats query failed")
 
     # VAPID公開鍵 (Web Push用、push_enabledの場合のみ)
     vapid_key = None
@@ -476,7 +477,8 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
         )
         user_count = user_result.scalar() or 0
     except Exception:
-        pass
+        import logging
+        logging.getLogger(__name__).exception("instance v2 user_count query failed")
 
     vapid_key = None
     try:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -24,6 +24,24 @@ async def test_instance_info_registrations(app_client):
     assert isinstance(data["registrations"], bool)
 
 
+async def test_instance_info_stats_reflect_db(app_client, db, mock_valkey):
+    """stats.user_count は実 DB 件数を反映する (#1006 回帰: select_from(literal_column(...)) で
+    SQLAlchemy が ArgumentError を投げ、try/except で握り潰されて常に 0 を返していた)。"""
+    from app.services.user_service import create_user
+
+    await create_user(db, "stats_user_1", "su1@example.com", "password1234")
+    await create_user(db, "stats_user_2", "su2@example.com", "password1234")
+    await db.commit()
+
+    resp = await app_client.get("/api/v1/instance")
+    data = resp.json()
+    stats = data["stats"]
+    assert isinstance(stats["user_count"], int)
+    assert isinstance(stats["status_count"], int)
+    assert isinstance(stats["domain_count"], int)
+    assert stats["user_count"] >= 2
+
+
 async def test_instance_contact_account(app_client, db, mock_valkey):
     """contact.account returns admin Account object for Mastodon client compat."""
     from app.services.user_service import create_user

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -25,12 +25,25 @@ async def test_instance_info_registrations(app_client):
 
 
 async def test_instance_info_stats_reflect_db(app_client, db, mock_valkey):
-    """stats.user_count は実 DB 件数を反映する (#1006 回帰: select_from(literal_column(...)) で
-    SQLAlchemy が ArgumentError を投げ、try/except で握り潰されて常に 0 を返していた)。"""
-    from app.services.user_service import create_user
+    """stats の3項目すべてが実 DB 件数を反映する (#1006 回帰: select_from(literal_column(...)) で
+    SQLAlchemy が ArgumentError を投げ、try/except で握り潰されて常に 0 を返していた)。
 
-    await create_user(db, "stats_user_1", "su1@example.com", "password1234")
+    将来 status_sq / domain_sq のどちらか単独で壊れた場合も検出するため、それぞれ実値 >= 1 を assert する。
+    """
+    from app.models.actor import Actor
+    from app.services.user_service import create_user
+    from tests.conftest import make_note, make_remote_actor
+
+    user = await create_user(db, "stats_user_1", "su1@example.com", "password1234")
     await create_user(db, "stats_user_2", "su2@example.com", "password1234")
+
+    # ローカル投稿を作って status_count を非ゼロに
+    actor = await db.get(Actor, user.actor_id)
+    await make_note(db, actor, content="stats test note")
+
+    # リモートアクターを作って domain_count を非ゼロに
+    await make_remote_actor(db, username="alice_stats", domain="stats.example")
+
     await db.commit()
 
     resp = await app_client.get("/api/v1/instance")
@@ -40,6 +53,8 @@ async def test_instance_info_stats_reflect_db(app_client, db, mock_valkey):
     assert isinstance(stats["status_count"], int)
     assert isinstance(stats["domain_count"], int)
     assert stats["user_count"] >= 2
+    assert stats["status_count"] >= 1
+    assert stats["domain_count"] >= 1
 
 
 async def test_instance_contact_account(app_client, db, mock_valkey):


### PR DESCRIPTION
Closes #1006

## 概要

ログイン前画面に表示される統計情報 (ユーザー数 / 投稿数 / 連合先サーバー数) が常に 0 で表示されない問題を修正。

## 原因

#976 で導入された統計クエリ最適化が SQLAlchemy 2 の API と非互換で、`select_from(literal_column("(SELECT 1) AS _dummy"))` が以下を投げていた:

```
ArgumentError: FROM expression, such as a Table or alias() object expected, got <ColumnClause>
```

直近の `except Exception: pass` で握り潰され、`user_count` / `status_count` / `domain_count` がすべて 0 のまま返されていた。本番 DB は実際は users=7, statuses=601, domains=465 を持つ。

## 修正

スカラサブクエリだけなら FROM 句不要なので `select_from(literal_column(...))` を削除。`literal_column` の import も不要になったため除去。

## 回帰テスト

`test_instance_info_stats_reflect_db`: 2 ユーザー作成 → `/api/v1/instance` の `stats.user_count >= 2` を assert。バグ時は 0 になるので必ず落ちる。

## 副作用ゼロ防止策 (claude-md)

`CLAUDE.md` (claude-md submodule) に再発防止の指針を追加:

- `except Exception: pass` で握り潰さない (最低 `logger.exception()`)
- クエリ最適化系の PR は実値を assert する回帰テストが必須

## Test plan

- [x] `pytest tests/test_main.py -v` 全 7 件 pass (新規 1 件含む)
- [ ] CI 通過
- [ ] Devin Review 確認
- [ ] マージ後、本番デプロイで `/api/v1/instance` の stats が非ゼロを返すことを確認
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/1007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
