### PR TITLE
chore(ci): pip-audit で CVE-2026-3219 を suppress

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -33,7 +33,13 @@ jobs:
           python-version: '3.12'
       - run: pip install pip-audit
       - run: pip install -e backend/
-      - run: pip-audit --ignore-vuln CVE-2026-4539  # pygments 2.19.2, no fix available yet
+      - run: |
+          pip-audit \
+            --ignore-vuln CVE-2026-4539 \
+            --ignore-vuln CVE-2026-3219
+          # CVE-2026-4539: pygments 2.19.2, no fix available yet
+          # CVE-2026-3219: pip 26.0.1 自身、修正版未リリース。tar+ZIP 連結ファイル誤認識 (CVSS 4.6
+          #   MEDIUM、AV:L + UI:A)。CI は信頼できる PyPI/自前依存のみ install するので実質リスクなし
 
   npm-audit:
     name: npm audit (Node.js)


### PR DESCRIPTION
## 概要

pip 26.0.1 自身に CVE-2026-3219 が報告されたが修正版未リリース。pip-audit が落ちて他 PR の CI を巻き込んでいるため `--ignore-vuln` で suppress する。

## リスク評価

- CVSS 4.6 (MEDIUM)
- AV:L (ローカル) + UI:A (ユーザー操作必須)
- VC:N VI:L VA:N (Integrity 低のみ)
- CI は信頼できる PyPI / 自前依存のみ install しており、攻撃ベクトルとなるユーザー入力アーカイブを処理しない
- 結論: 実質的リスクなし、修正版リリースまで suppress で問題なし

## 解除タイミング

pip 側で修正版がリリースされたら `--ignore-vuln CVE-2026-3219` を削除する。

## Test plan

- [ ] CI 通過 (これが本来の目的)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/1008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->