### PR TITLE
Release 20260502-1

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,28 @@
+name: Claude Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: >-
+      github.event.pull_request.draft == false &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: nekonoverse/nekonaudit@main
+        with:
+          flavor: python-backend
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -33,7 +33,13 @@ jobs:
           python-version: '3.12'
       - run: pip install pip-audit
       - run: pip install -e backend/
-      - run: pip-audit --ignore-vuln CVE-2026-4539  # pygments 2.19.2, no fix available yet
+      - run: |
+          pip-audit \
+            --ignore-vuln CVE-2026-4539 \
+            --ignore-vuln CVE-2026-3219
+          # CVE-2026-4539: pygments 2.19.2, no fix available yet
+          # CVE-2026-3219: pip 26.0.1 自身、修正版未リリース。tar+ZIP 連結ファイル誤認識 (CVSS 4.6
+          #   MEDIUM、AV:L + UI:A)。CI は信頼できる PyPI/自前依存のみ install するので実質リスクなし
 
   npm-audit:
     name: npm audit (Node.js)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [20260502-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260502-1) — 2026-05-02
+
+### バグ修正
+
+- **`/api/v1/instance` の `stats` が常に 0 を返すバグを修正** — #976 で導入された統計クエリ最適化 (`select_from(literal_column("(SELECT 1) AS _dummy"))`) が SQLAlchemy 2 と非互換で `ArgumentError` を投げ、`except Exception: pass` で握り潰されてログイン前画面の統計が描画されない状態だった。同関数内 + v2 instance 側の同パターンの except も `logger.exception()` 化し、握り潰し再発を防止 (#1006, #1007)
+
+### 依存関係
+
+- **postcss 8.5.8 → 8.5.13** — 8.5.10 (XSS) / 8.5.12 (任意ファイル読み取り) の security fix を含む。Vite 経由の build-time devDep のため実環境への影響は軽微 (#1005)
+
+### CI / セキュリティ
+
+- **pip-audit で CVE-2026-3219 (pip 自身の未修正脆弱性) を suppress** — pip 26.0.1 自身の tar+ZIP 連結ファイル誤認識 CVE。修正版未リリースだが CVSS 4.6 (MEDIUM) + AV:L + UI:A で CI 環境では実質リスクなし。修正版リリース後に解除予定 (#1008)
+
+### 運用ドキュメント
+
+- **CLAUDE.md (claude-md submodule)**: `except Exception: pass` で握り潰さない方針 + クエリ最適化系の PR は実値 assert する回帰テスト必須を追加
+
+---
+
 ## [20260423-2](https://github.com/nekonoverse/nekonoverse/releases/tag/20260423-2) — 2026-04-23
 
 ### パフォーマンス

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260423-2"
+__version__ = "20260502-1"
 
 
 def _resolve_version() -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -233,7 +233,7 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
     except Exception:
         pass
 
-    from sqlalchemy import func, literal_column, select
+    from sqlalchemy import func, select
 
     from app.models.actor import Actor
     from app.models.note import Note
@@ -310,14 +310,15 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
                 user_sq.label("users"),
                 status_sq.label("statuses"),
                 domain_sq.label("domains"),
-            ).select_from(literal_column("(SELECT 1) AS _dummy"))
+            )
         )
         stats_row = stats_result.one()
         user_count = stats_row.users or 0
         status_count = stats_row.statuses or 0
         domain_count = stats_row.domains or 0
     except Exception:
-        pass
+        import logging
+        logging.getLogger(__name__).exception("instance v1 stats query failed")
 
     # VAPID公開鍵 (Web Push用、push_enabledの場合のみ)
     vapid_key = None
@@ -476,7 +477,8 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
         )
         user_count = user_result.scalar() or 0
     except Exception:
-        pass
+        import logging
+        logging.getLogger(__name__).exception("instance v2 user_count query failed")
 
     vapid_key = None
     try:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260423-2"
+version = "20260502-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -24,6 +24,39 @@ async def test_instance_info_registrations(app_client):
     assert isinstance(data["registrations"], bool)
 
 
+async def test_instance_info_stats_reflect_db(app_client, db, mock_valkey):
+    """stats の3項目すべてが実 DB 件数を反映する (#1006 回帰: select_from(literal_column(...)) で
+    SQLAlchemy が ArgumentError を投げ、try/except で握り潰されて常に 0 を返していた)。
+
+    将来 status_sq / domain_sq のどちらか単独で壊れた場合も検出するため、それぞれ実値 >= 1 を assert する。
+    """
+    from app.models.actor import Actor
+    from app.services.user_service import create_user
+    from tests.conftest import make_note, make_remote_actor
+
+    user = await create_user(db, "stats_user_1", "su1@example.com", "password1234")
+    await create_user(db, "stats_user_2", "su2@example.com", "password1234")
+
+    # ローカル投稿を作って status_count を非ゼロに
+    actor = await db.get(Actor, user.actor_id)
+    await make_note(db, actor, content="stats test note")
+
+    # リモートアクターを作って domain_count を非ゼロに
+    await make_remote_actor(db, username="alice_stats", domain="stats.example")
+
+    await db.commit()
+
+    resp = await app_client.get("/api/v1/instance")
+    data = resp.json()
+    stats = data["stats"]
+    assert isinstance(stats["user_count"], int)
+    assert isinstance(stats["status_count"], int)
+    assert isinstance(stats["domain_count"], int)
+    assert stats["user_count"] >= 2
+    assert stats["status_count"] >= 1
+    assert stats["domain_count"] >= 1
+
+
 async def test_instance_contact_account(app_client, db, mock_valkey):
     """contact.account returns admin Account object for Mastodon client compat."""
     from app.services.user_service import create_user

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -137,10 +137,10 @@ FROM pg_stat_user_tables WHERE relname='delivery_queue';
 "
 
 # 既存の delivered を purge してから VACUUM FULL（テーブルロックが走るので深夜帯推奨）
-docker compose exec postgresql psql -U nekonoverse -d nekonoverse -c "
-DELETE FROM delivery_queue WHERE status='delivered' AND created_at < now() - interval '24 hours';
-VACUUM FULL delivery_queue;
-"
+# VACUUM FULL はトランザクション内で実行できないため `-c` を分ける必要がある
+docker compose exec postgresql psql -U nekonoverse -d nekonoverse \
+  -c "DELETE FROM delivery_queue WHERE status='delivered' AND created_at < now() - interval '24 hours';" \
+  -c "VACUUM FULL delivery_queue;"
 ```
 
 ### Docker イメージタグ

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260423-2",
+  "version": "20260502-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260423-2",
+      "version": "20260502-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260416-1",
+  "version": "20260423-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260416-1",
+      "version": "20260423-2",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",
@@ -5617,7 +5617,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260423-2",
+  "version": "20260502-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## バグ修正

- **`/api/v1/instance` の `stats` が常に 0 を返すバグを修正** — #976 で導入された統計クエリ最適化が SQLAlchemy 2 と非互換で握り潰されていたものを修正、回帰テスト追加 + 同パターンの except を `logger.exception()` 化 (#1006, #1007)

## 依存関係

- **postcss 8.5.8 → 8.5.13** — security fix を含む (#1005)

## CI / セキュリティ

- **pip-audit で CVE-2026-3219 を suppress** — pip 自身の未修正脆弱性、CI 環境では実質リスクなし (#1008)

## 運用ドキュメント

- CLAUDE.md (claude-md submodule) に「`except Exception: pass` で握り潰さない」「クエリ最適化系は実値 assert する回帰テスト必須」を追加
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/1009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->