### PR TITLE
chore: docker-compose.prod.yml の media-proxy-rs UDS 例を distroless 対応に更新 (#1011)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -276,17 +276,13 @@ services:
   # Optional: media-proxy-rs (uncomment to use)
   # 画像変換専用。/transform POST のみ使用するため外部アクセス不要。
   # network_mode: "none" で TCP を無効化し UDS のみで通信。
+  # イメージは distroless ベース (shell / chown / su なし) なので、socket 用 named volume は
+  # tmpfs + uid/gid 指定で初回から 852 所有にし、コンテナ自体は 852 で直接起動する。
   # media-proxy-rs:
   #   image: ghcr.io/nekonoverse/media-proxy-rs:main
   #   restart: unless-stopped
   #   network_mode: "none"
-  #   user: "0:0"
-  #   command:
-  #     - sh
-  #     - -c
-  #     - |
-  #       chown 852:852 /var/run/media-proxy-rs &&
-  #       exec su -s /bin/sh proxy -c './media-proxy-rs'
+  #   user: "852:852"
   #   deploy:
   #     resources:
   #       limits:
@@ -428,7 +424,12 @@ volumes:
   # face-detect UDS 使用時はコメント解除
   # face_detect_sock:
   # media-proxy-rs UDS 使用時はコメント解除
+  # (distroless イメージは chown を持たないため tmpfs + uid/gid 指定で 852 所有を初期化する)
   # media_proxy_rs_sock:
+  #   driver_opts:
+  #     type: tmpfs
+  #     device: tmpfs
+  #     o: "uid=852,gid=852,mode=0770"
   # neko-vision UDS 使用時はコメント解除
   # neko_vision_sock:
   # video-thumb UDS 使用時はコメント解除


### PR DESCRIPTION
Closes #1011

## 概要

[nekonoverse/media-proxy-rs#6](https://github.com/nekonoverse/media-proxy-rs/pull/6) で runtime image が distroless 化されたが、`docker-compose.prod.yml` のサンプル設定が `sh -c "chown ... && su"` パターンのままだった。distroless には shell / chown / su が無いため利用者がコメント解除しても起動失敗する。

## 修正内容

- `services.media-proxy-rs`: `user: "0:0"` + `command: sh -c ...` を削除し `user: "852:852"` で直接起動
- `volumes.media_proxy_rs_sock`: tmpfs ベースの named volume にし `driver_opts.o: "uid=852,gid=852,mode=0770"` で初期化時から 852 所有

両者ともコメントアウト済みブロックなので、コメント解除して使う利用者だけが恩恵を受ける。**機能影響なし**。

## Test plan

- [ ] CI 通過
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nekonoverse/nekonoverse/pull/1012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->