### PR TITLE
perf: 動画サムネ生成を S3 presigned URL 渡しに切替 (#1013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 未リリース
+
+### パフォーマンス
+
+- **動画サムネ生成を S3 presigned URL 渡しに切替** — 旧来「backend が S3 から動画フル DL → multipart POST → video-thumb が tempfile に書く」の流れを「presigned URL を JSON で送る → video-thumb が HTTP Range で先頭フレームのみ取得」に変更。backend のメモリ使用量と backend↔video-thumb 間の帯域がほぼゼロに、video-thumb 側の tempfile も不要になり大容量動画でも高速化 (#1013, #1014)
+
+---
+
 ## [20260502-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260502-1) — 2026-05-02
 
 ### バグ修正

--- a/backend/app/services/video_thumb_queue.py
+++ b/backend/app/services/video_thumb_queue.py
@@ -64,12 +64,17 @@ async def enqueue_remote(note_id: uuid.UUID, attachment_ids: list[uuid.UUID]) ->
 
 
 async def _process_local(job: dict) -> None:
-    """ローカルDriveFileのサムネイル生成ジョブを処理する。"""
+    """ローカルDriveFileのサムネイル生成ジョブを処理する。
+
+    S3 presigned URL を生成して video-thumb の `/thumbnail_from_url` に投げる。
+    backend は動画をメモリにロードせず、video-thumb 側も HTTP Range で先頭フレーム
+    周辺だけ取得するため、メモリ・帯域・ディスクをほとんど消費しない。
+    """
     from sqlalchemy import select
 
     from app.database import async_session
     from app.models.drive_file import DriveFile
-    from app.storage import download_file, upload_file
+    from app.storage import generate_presigned_get_url, upload_file
     from app.utils.http_client import make_video_thumb_client
 
     drive_file_id = uuid.UUID(job["drive_file_id"])
@@ -90,18 +95,16 @@ async def _process_local(job: dict) -> None:
             )
             return
 
-        # S3 から動画をダウンロード
-        video_data = await download_file(drive_file.s3_key)
+        # S3 presigned URL を生成 (video-thumb はこの URL から HTTP Range で取得)
+        # 有効期限はサムネ生成 1 回分 + リトライ余裕として 5 分
+        video_url = generate_presigned_get_url(drive_file.s3_key, expires_in=300)
 
-        # video-thumb サービスにリクエスト
+        # video-thumb サービスに URL を渡す
         base = settings.video_thumb_base_url
-        url = f"{base}/thumbnail" if not base.endswith("/thumbnail") else base
+        url = f"{base}/thumbnail_from_url"
 
         async with make_video_thumb_client() as client:
-            resp = await client.post(
-                url,
-                files={"file": ("video", video_data, drive_file.mime_type)},
-            )
+            resp = await client.post(url, json={"url": video_url})
             resp.raise_for_status()
 
         thumb_data = resp.content

--- a/backend/app/services/video_thumb_queue.py
+++ b/backend/app/services/video_thumb_queue.py
@@ -95,8 +95,9 @@ async def _process_local(job: dict) -> None:
             )
             return
 
-        # S3 presigned URL を生成 (video-thumb はこの URL から HTTP Range で取得)
-        # 有効期限はサムネ生成 1 回分 + リトライ余裕として 5 分
+        # S3 presigned URL を生成 (video-thumb はこの URL から HTTP Range で取得)。
+        # 有効期限はサムネ生成 1 回分の処理時間に余裕を持たせて 5 分。リトライで遅延しても
+        # URL は `_process_local` 実行時に毎回再発行されるので、再 enqueue 時点で再生成される。
         video_url = generate_presigned_get_url(drive_file.s3_key, expires_in=300)
 
         # video-thumb サービスに URL を渡す

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -183,11 +183,18 @@ def generate_presigned_get_url(key: str, expires_in: int = 300) -> str:
 
     Args:
         key: S3 object key (bucket prefix なし)
-        expires_in: 有効期限 (秒、最大 7 日 = 604800)
+        expires_in: 有効期限 (秒、1 〜 604800 = 7 日)
 
     Returns:
         presigned URL (`{s3_endpoint_url}/{bucket}/{key}?X-Amz-Algorithm=...`)
+
+    Raises:
+        ValueError: expires_in が AWS 仕様の範囲 (1-604800 秒) を超える場合
     """
+    if not 1 <= expires_in <= 604800:
+        raise ValueError(
+            f"expires_in must be between 1 and 604800 seconds, got {expires_in}"
+        )
     now = datetime.now(timezone.utc)
     date_str = now.strftime("%Y%m%d")
     amz_date = now.strftime("%Y%m%dT%H%M%SZ")

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -173,3 +173,72 @@ async def get_file_stream(key: str) -> tuple[AsyncIterator[bytes], str, int]:
 def get_public_url(key: str) -> str:
     """指定された S3 キーの公開 URL を返す。"""
     return f"{settings.media_url}/{key}"
+
+
+def generate_presigned_get_url(key: str, expires_in: int = 300) -> str:
+    """S3 オブジェクトの GET 用 presigned URL を返す (AWS SigV4 query string 方式)。
+
+    video-thumb の `/thumbnail_from_url` 等、内部マイクロサービスから一時的に
+    S3 オブジェクトを取得させたい場面で使う。
+
+    Args:
+        key: S3 object key (bucket prefix なし)
+        expires_in: 有効期限 (秒、最大 7 日 = 604800)
+
+    Returns:
+        presigned URL (`{s3_endpoint_url}/{bucket}/{key}?X-Amz-Algorithm=...`)
+    """
+    now = datetime.now(timezone.utc)
+    date_str = now.strftime("%Y%m%d")
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    credential_scope = f"{date_str}/{settings.s3_region}/s3/aws4_request"
+
+    host = _endpoint_host()
+    path = f"/{settings.s3_bucket}/{key}"
+    canonical_uri = quote(path, safe="/")
+
+    # 署名対象は host ヘッダのみ (presigned URL の慣習)
+    signed_headers = "host"
+    canonical_headers = f"host:{host}\n"
+
+    # クエリ文字列 (キー名はソートする必要がある)
+    query_params = {
+        "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+        "X-Amz-Credential": f"{settings.s3_access_key_id}/{credential_scope}",
+        "X-Amz-Date": amz_date,
+        "X-Amz-Expires": str(expires_in),
+        "X-Amz-SignedHeaders": signed_headers,
+    }
+    canonical_query = "&".join(
+        f"{quote(k, safe='-_.~')}={quote(v, safe='-_.~')}"
+        for k, v in sorted(query_params.items())
+    )
+
+    canonical_request = "\n".join(
+        [
+            "GET",
+            canonical_uri,
+            canonical_query,
+            canonical_headers,
+            signed_headers,
+            "UNSIGNED-PAYLOAD",
+        ]
+    )
+    string_to_sign = "\n".join(
+        [
+            "AWS4-HMAC-SHA256",
+            amz_date,
+            credential_scope,
+            hashlib.sha256(canonical_request.encode()).hexdigest(),
+        ]
+    )
+    signature = hmac.new(
+        _signing_key(date_str),
+        string_to_sign.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return (
+        f"{settings.s3_endpoint_url}{canonical_uri}"
+        f"?{canonical_query}&X-Amz-Signature={signature}"
+    )

--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -158,3 +158,15 @@ def test_generate_presigned_get_url_url_safe_encoding():
 
     url = generate_presigned_get_url("path/to/file.with.dots.mp4", expires_in=60)
     assert "/path/to/file.with.dots.mp4?" in url
+
+
+def test_generate_presigned_get_url_rejects_invalid_expires_in():
+    """expires_in は AWS 仕様 (1-604800 秒) の範囲外で ValueError。"""
+    from app.storage import generate_presigned_get_url
+
+    with pytest.raises(ValueError):
+        generate_presigned_get_url("k", expires_in=0)
+    with pytest.raises(ValueError):
+        generate_presigned_get_url("k", expires_in=-1)
+    with pytest.raises(ValueError):
+        generate_presigned_get_url("k", expires_in=604801)

--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -118,3 +118,43 @@ def test_auth_headers_contain_authorization():
     assert "Authorization" in headers
     assert "AWS4-HMAC-SHA256" in headers["Authorization"]
     assert "x-amz-date" in headers
+
+
+# ── generate_presigned_get_url ───────────────────────────────────────────
+
+
+def test_generate_presigned_get_url_format():
+    """presigned URL に必要なクエリパラメータが含まれる。"""
+    from app.storage import generate_presigned_get_url
+
+    url = generate_presigned_get_url("u/abc/test.mp4", expires_in=300)
+
+    # endpoint + bucket + key
+    assert url.startswith("http://nekono3s:8080/nekonoverse/u/abc/test.mp4?")
+    # AWS SigV4 query parameters
+    assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in url
+    assert "X-Amz-Credential=" in url
+    assert "X-Amz-Date=" in url
+    assert "X-Amz-Expires=300" in url
+    assert "X-Amz-SignedHeaders=host" in url
+    assert "X-Amz-Signature=" in url
+
+
+def test_generate_presigned_get_url_distinct_signatures_for_different_keys():
+    """異なる key は異なる署名になる。"""
+    from app.storage import generate_presigned_get_url
+
+    url1 = generate_presigned_get_url("a.mp4", expires_in=300)
+    url2 = generate_presigned_get_url("b.mp4", expires_in=300)
+
+    sig1 = url1.split("X-Amz-Signature=")[1]
+    sig2 = url2.split("X-Amz-Signature=")[1]
+    assert sig1 != sig2
+
+
+def test_generate_presigned_get_url_url_safe_encoding():
+    """key に / や . を含んでも URL エンコードが壊れない。"""
+    from app.storage import generate_presigned_get_url
+
+    url = generate_presigned_get_url("path/to/file.with.dots.mp4", expires_in=60)
+    assert "/path/to/file.with.dots.mp4?" in url

--- a/backend/tests/test_video_thumb_queue.py
+++ b/backend/tests/test_video_thumb_queue.py
@@ -159,7 +159,10 @@ async def test_process_local_generates_thumbnail(mock_valkey):
 
     with (
         patch("app.database.async_session", return_value=mock_session),
-        patch("app.storage.download_file", new_callable=AsyncMock) as mock_dl,
+        patch(
+            "app.storage.generate_presigned_get_url",
+            return_value="http://nekono3s:8080/nekonoverse/u/abc/test.mp4?X-Amz-Signature=abc",
+        ) as mock_presign,
         patch("app.storage.upload_file", new_callable=AsyncMock) as mock_ul,
         patch(
             "app.utils.http_client.make_video_thumb_client", return_value=mock_client
@@ -167,11 +170,17 @@ async def test_process_local_generates_thumbnail(mock_valkey):
         patch("app.services.video_thumb_queue.settings") as mock_settings,
     ):
         mock_settings.video_thumb_base_url = "http://video-thumb:8005"
-        mock_dl.return_value = b"video-data"
 
         await _process_local({"drive_file_id": str(uuid.uuid4())})
 
-    mock_dl.assert_called_once_with("u/abc/test.mp4")
+    # 動画は DL せず presigned URL を生成 → /thumbnail_from_url に JSON で渡す
+    mock_presign.assert_called_once_with("u/abc/test.mp4", expires_in=300)
+    mock_client.post.assert_called_once()
+    call_args, call_kwargs = mock_client.post.call_args
+    assert call_args[0] == "http://video-thumb:8005/thumbnail_from_url"
+    assert call_kwargs["json"] == {
+        "url": "http://nekono3s:8080/nekonoverse/u/abc/test.mp4?X-Amz-Signature=abc"
+    }
     mock_ul.assert_called_once_with("thumb/u/abc/test.mp4.webp", thumb_bytes, "image/webp")
     assert mock_file.thumbnail_s3_key == "thumb/u/abc/test.mp4.webp"
     assert mock_file.thumbnail_mime_type == "image/webp"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -345,6 +345,9 @@ services:
   #       chown 101:101 /var/run/video-thumb &&
   #       exec setpriv --reuid=101 --regid=101 --clear-groups \
   #         uvicorn main:app --uds /var/run/video-thumb/uvicorn.sock
+  #   environment:
+  #     # nekono3s が private IP に解決されるため /thumbnail_from_url で許可する
+  #     ALLOW_PRIVATE_URL: "1"
   #   volumes:
   #     - video_thumb_sock:/var/run/video-thumb
 

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -261,6 +261,9 @@ services:
   # video-thumb:
   #   image: ghcr.io/nekonoverse/video-thumb:latest
   #   restart: unless-stopped
+  #   environment:
+  #     # nekono3s が private IP に解決されるため /thumbnail_from_url で許可する
+  #     ALLOW_PRIVATE_URL: "1"
   #   expose:
   #     - "8005"
 


### PR DESCRIPTION
Closes #1013

## 概要

[nekonoverse/video-thumb#2](https://github.com/nekonoverse/video-thumb/pull/2) で video-thumb 側に `/thumbnail_from_url` (JSON URL 受付 + HEAD 403/405 → GET Range フォールバック) が入ったことを受け、worker の動画サムネ生成を「S3 フル DL → multipart POST」から「presigned URL 生成 → JSON POST」に切替。

## 改善内容

### Before

```
S3 → backend が動画フル DL (メモリに全部) → multipart POST → video-thumb が tempfile に書く → ffmpeg
```

### After

```
backend が S3 presigned GET URL を生成 → JSON で URL のみ POST → video-thumb が HEAD 403/405 → GET Range で Content-Range 取得 → ffmpeg に直接 URL 渡す → HTTP Range で先頭フレームのみ DL
```

## 期待効果

- backend のメモリ使用量 ~0 (URL 生成のみ)
- backend↔video-thumb 帯域 ~0 (JSON URL のみ)
- video-thumb 側の tempfile 不要
- 大容量動画でも HTTP Range で先頭フレームだけ取得可能

## 修正内容

- `app/storage.py`: `generate_presigned_get_url(key, expires_in=300)` を追加 (AWS SigV4 query string 方式)
- `app/services/video_thumb_queue.py`: `_process_local` で `download_file` を廃止し presigned URL を `/thumbnail_from_url` に渡す方式に変更
- `docker-compose.{yml.example,prod.yml}`: video-thumb サービスに `ALLOW_PRIVATE_URL=1` 追加 (nekono3s が private IP に解決されるため)
- テスト: `test_storage_extended.py` に presigned URL 検証 3 件、`test_video_thumb_queue.py` で URL モードでの POST 検証に更新

## 互換性

- video-thumb 側は `/thumbnail` (multipart) も維持しているため、ロールバックは可能
- ただし nekonoverse の本 PR マージ後は `/thumbnail_from_url` が必須となるため、video-thumb は upstream/main 取り込み済みのイメージ (現時点で最新) を使うこと

## Test plan

- [ ] `pytest tests/test_storage_extended.py tests/test_video_thumb_queue.py -v` 全 19 件 pass
- [ ] CI 通過
- [ ] 本番デプロイ後、動画アップロード → サムネ生成の動作確認