### PR TITLE
Release 20260504-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 未リリース
+
+### パフォーマンス
+
+- **動画サムネ生成を S3 presigned URL 渡しに切替** — 旧来「backend が S3 から動画フル DL → multipart POST → video-thumb が tempfile に書く」の流れを「presigned URL を JSON で送る → video-thumb が HTTP Range で先頭フレームのみ取得」に変更。backend のメモリ使用量と backend↔video-thumb 間の帯域がほぼゼロに、video-thumb 側の tempfile も不要になり大容量動画でも高速化 (#1013, #1014)
+
+---
+
 ## [20260502-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260502-1) — 2026-05-02
 
 ### バグ修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### 運用上の注意
 
 - 本リリースから video-thumb イメージは **`/thumbnail_from_url` 対応版が必須**。`docker compose pull` で video-thumb の最新イメージを取得すること。nekono3s が private IP に解決されるため、video-thumb サービスの環境変数に `ALLOW_PRIVATE_URL=1` を設定する必要あり (`docker-compose.yml.example` / `docker-compose.prod.yml` のサンプルに反映済み)
+- ⚠️ `ALLOW_PRIVATE_URL=1` はプライベート IP 宛 HTTP fetch を許可するため、video-thumb は **backend/worker からのみ到達可能なネットワーク境界** で運用すること (`docker-compose.prod.yml` の UDS 構成または同等の隔離)。サンプルコメントにも明記済み
+
+### インフラ
+
+- **`docker-compose.prod.yml` の `media-proxy-rs` UDS 設定例を distroless 対応に更新** — runtime image が distroless/static-debian13 化された ([nekonoverse/media-proxy-rs#6](https://github.com/nekonoverse/media-proxy-rs/pull/6)) ことに伴い、`sh -c "chown..."` パターンを廃止し socket volume を tmpfs + uid/gid 指定で初期化する形式に。コメントアウト済みブロックなので機能影響なし (#1011, #1012)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 未リリース
+## [20260504-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260504-1) — 2026-05-04
 
 ### パフォーマンス
 
 - **動画サムネ生成を S3 presigned URL 渡しに切替** — 旧来「backend が S3 から動画フル DL → multipart POST → video-thumb が tempfile に書く」の流れを「presigned URL を JSON で送る → video-thumb が HTTP Range で先頭フレームのみ取得」に変更。backend のメモリ使用量と backend↔video-thumb 間の帯域がほぼゼロに、video-thumb 側の tempfile も不要になり大容量動画でも高速化 (#1013, #1014)
+
+### 運用上の注意
+
+- 本リリースから video-thumb イメージは **`/thumbnail_from_url` 対応版が必須**。`docker compose pull` で video-thumb の最新イメージを取得すること。nekono3s が private IP に解決されるため、video-thumb サービスの環境変数に `ALLOW_PRIVATE_URL=1` を設定する必要あり (`docker-compose.yml.example` / `docker-compose.prod.yml` のサンプルに反映済み)
 
 ---
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260502-1"
+__version__ = "20260504-1"
 
 
 def _resolve_version() -> str:

--- a/backend/app/services/video_thumb_queue.py
+++ b/backend/app/services/video_thumb_queue.py
@@ -64,12 +64,17 @@ async def enqueue_remote(note_id: uuid.UUID, attachment_ids: list[uuid.UUID]) ->
 
 
 async def _process_local(job: dict) -> None:
-    """ローカルDriveFileのサムネイル生成ジョブを処理する。"""
+    """ローカルDriveFileのサムネイル生成ジョブを処理する。
+
+    S3 presigned URL を生成して video-thumb の `/thumbnail_from_url` に投げる。
+    backend は動画をメモリにロードせず、video-thumb 側も HTTP Range で先頭フレーム
+    周辺だけ取得するため、メモリ・帯域・ディスクをほとんど消費しない。
+    """
     from sqlalchemy import select
 
     from app.database import async_session
     from app.models.drive_file import DriveFile
-    from app.storage import download_file, upload_file
+    from app.storage import generate_presigned_get_url, upload_file
     from app.utils.http_client import make_video_thumb_client
 
     drive_file_id = uuid.UUID(job["drive_file_id"])
@@ -90,18 +95,17 @@ async def _process_local(job: dict) -> None:
             )
             return
 
-        # S3 から動画をダウンロード
-        video_data = await download_file(drive_file.s3_key)
+        # S3 presigned URL を生成 (video-thumb はこの URL から HTTP Range で取得)。
+        # 有効期限はサムネ生成 1 回分の処理時間に余裕を持たせて 5 分。リトライで遅延しても
+        # URL は `_process_local` 実行時に毎回再発行されるので、再 enqueue 時点で再生成される。
+        video_url = generate_presigned_get_url(drive_file.s3_key, expires_in=300)
 
-        # video-thumb サービスにリクエスト
+        # video-thumb サービスに URL を渡す
         base = settings.video_thumb_base_url
-        url = f"{base}/thumbnail" if not base.endswith("/thumbnail") else base
+        url = f"{base}/thumbnail_from_url"
 
         async with make_video_thumb_client() as client:
-            resp = await client.post(
-                url,
-                files={"file": ("video", video_data, drive_file.mime_type)},
-            )
+            resp = await client.post(url, json={"url": video_url})
             resp.raise_for_status()
 
         thumb_data = resp.content

--- a/backend/app/services/video_thumb_queue.py
+++ b/backend/app/services/video_thumb_queue.py
@@ -25,7 +25,9 @@ DEAD_KEY = "video_thumb:dead"
 HEARTBEAT_KEY = "worker:video_thumb:heartbeat"
 
 MAX_ATTEMPTS = 5
-MAX_CONCURRENT = 2  # 動画処理はCPU/メモリ集約的
+# 動画は presigned URL を渡すだけで backend 側は CPU/メモリ集約的でないが、
+# video-thumb (FFmpeg) が同時並列処理できる本数の方が実質的な律速。デフォルトは保守的に 2 並列。
+MAX_CONCURRENT = 2
 
 _VIDEO_MIMES = {"video/mp4", "video/webm", "video/quicktime", "video/x-matroska"}
 
@@ -97,7 +99,7 @@ async def _process_local(job: dict) -> None:
 
         # S3 presigned URL を生成 (video-thumb はこの URL から HTTP Range で取得)。
         # 有効期限はサムネ生成 1 回分の処理時間に余裕を持たせて 5 分。リトライで遅延しても
-        # URL は `_process_local` 実行時に毎回再発行されるので、再 enqueue 時点で再生成される。
+        # URL は `_process_local` 再実行時に毎回再発行される。
         video_url = generate_presigned_get_url(drive_file.s3_key, expires_in=300)
 
         # video-thumb サービスに URL を渡す

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -173,3 +173,79 @@ async def get_file_stream(key: str) -> tuple[AsyncIterator[bytes], str, int]:
 def get_public_url(key: str) -> str:
     """指定された S3 キーの公開 URL を返す。"""
     return f"{settings.media_url}/{key}"
+
+
+def generate_presigned_get_url(key: str, expires_in: int = 300) -> str:
+    """S3 オブジェクトの GET 用 presigned URL を返す (AWS SigV4 query string 方式)。
+
+    video-thumb の `/thumbnail_from_url` 等、内部マイクロサービスから一時的に
+    S3 オブジェクトを取得させたい場面で使う。
+
+    Args:
+        key: S3 object key (bucket prefix なし)
+        expires_in: 有効期限 (秒、1 〜 604800 = 7 日)
+
+    Returns:
+        presigned URL (`{s3_endpoint_url}/{bucket}/{key}?X-Amz-Algorithm=...`)
+
+    Raises:
+        ValueError: expires_in が AWS 仕様の範囲 (1-604800 秒) を超える場合
+    """
+    if not 1 <= expires_in <= 604800:
+        raise ValueError(
+            f"expires_in must be between 1 and 604800 seconds, got {expires_in}"
+        )
+    now = datetime.now(timezone.utc)
+    date_str = now.strftime("%Y%m%d")
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    credential_scope = f"{date_str}/{settings.s3_region}/s3/aws4_request"
+
+    host = _endpoint_host()
+    path = f"/{settings.s3_bucket}/{key}"
+    canonical_uri = quote(path, safe="/")
+
+    # 署名対象は host ヘッダのみ (presigned URL の慣習)
+    signed_headers = "host"
+    canonical_headers = f"host:{host}\n"
+
+    # クエリ文字列 (キー名はソートする必要がある)
+    query_params = {
+        "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+        "X-Amz-Credential": f"{settings.s3_access_key_id}/{credential_scope}",
+        "X-Amz-Date": amz_date,
+        "X-Amz-Expires": str(expires_in),
+        "X-Amz-SignedHeaders": signed_headers,
+    }
+    canonical_query = "&".join(
+        f"{quote(k, safe='-_.~')}={quote(v, safe='-_.~')}"
+        for k, v in sorted(query_params.items())
+    )
+
+    canonical_request = "\n".join(
+        [
+            "GET",
+            canonical_uri,
+            canonical_query,
+            canonical_headers,
+            signed_headers,
+            "UNSIGNED-PAYLOAD",
+        ]
+    )
+    string_to_sign = "\n".join(
+        [
+            "AWS4-HMAC-SHA256",
+            amz_date,
+            credential_scope,
+            hashlib.sha256(canonical_request.encode()).hexdigest(),
+        ]
+    )
+    signature = hmac.new(
+        _signing_key(date_str),
+        string_to_sign.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return (
+        f"{settings.s3_endpoint_url}{canonical_uri}"
+        f"?{canonical_query}&X-Amz-Signature={signature}"
+    )

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -193,7 +193,7 @@ def generate_presigned_get_url(key: str, expires_in: int = 300) -> str:
     """
     if not 1 <= expires_in <= 604800:
         raise ValueError(
-            f"expires_in must be between 1 and 604800 seconds, got {expires_in}"
+            f"expires_in は 1 〜 604800 秒の範囲で指定してください (got {expires_in})"
         )
     now = datetime.now(timezone.utc)
     date_str = now.strftime("%Y%m%d")
@@ -245,7 +245,9 @@ def generate_presigned_get_url(key: str, expires_in: int = 300) -> str:
         hashlib.sha256,
     ).hexdigest()
 
+    # endpoint URL に末尾スラッシュがあると `//bucket/key` になるため除去
+    endpoint = settings.s3_endpoint_url.rstrip("/")
     return (
-        f"{settings.s3_endpoint_url}{canonical_uri}"
+        f"{endpoint}{canonical_uri}"
         f"?{canonical_query}&X-Amz-Signature={signature}"
     )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260502-1"
+version = "20260504-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -170,3 +170,19 @@ def test_generate_presigned_get_url_rejects_invalid_expires_in():
         generate_presigned_get_url("k", expires_in=-1)
     with pytest.raises(ValueError):
         generate_presigned_get_url("k", expires_in=604801)
+
+
+def test_generate_presigned_get_url_strips_trailing_slash():
+    """endpoint URL に末尾スラッシュがあっても `//bucket/key` にならない。"""
+    import app.storage
+    from app.storage import generate_presigned_get_url
+
+    # settings.s3_endpoint_url を一時的に末尾スラッシュ付きに
+    orig = app.storage.settings.s3_endpoint_url
+    try:
+        app.storage.settings.s3_endpoint_url = "http://nekono3s:8080/"
+        url = generate_presigned_get_url("test.mp4", expires_in=60)
+        assert url.startswith("http://nekono3s:8080/nekonoverse/test.mp4?")
+        assert "//nekonoverse" not in url
+    finally:
+        app.storage.settings.s3_endpoint_url = orig

--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -118,3 +118,55 @@ def test_auth_headers_contain_authorization():
     assert "Authorization" in headers
     assert "AWS4-HMAC-SHA256" in headers["Authorization"]
     assert "x-amz-date" in headers
+
+
+# ── generate_presigned_get_url ───────────────────────────────────────────
+
+
+def test_generate_presigned_get_url_format():
+    """presigned URL に必要なクエリパラメータが含まれる。"""
+    from app.storage import generate_presigned_get_url
+
+    url = generate_presigned_get_url("u/abc/test.mp4", expires_in=300)
+
+    # endpoint + bucket + key
+    assert url.startswith("http://nekono3s:8080/nekonoverse/u/abc/test.mp4?")
+    # AWS SigV4 query parameters
+    assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in url
+    assert "X-Amz-Credential=" in url
+    assert "X-Amz-Date=" in url
+    assert "X-Amz-Expires=300" in url
+    assert "X-Amz-SignedHeaders=host" in url
+    assert "X-Amz-Signature=" in url
+
+
+def test_generate_presigned_get_url_distinct_signatures_for_different_keys():
+    """異なる key は異なる署名になる。"""
+    from app.storage import generate_presigned_get_url
+
+    url1 = generate_presigned_get_url("a.mp4", expires_in=300)
+    url2 = generate_presigned_get_url("b.mp4", expires_in=300)
+
+    sig1 = url1.split("X-Amz-Signature=")[1]
+    sig2 = url2.split("X-Amz-Signature=")[1]
+    assert sig1 != sig2
+
+
+def test_generate_presigned_get_url_url_safe_encoding():
+    """key に / や . を含んでも URL エンコードが壊れない。"""
+    from app.storage import generate_presigned_get_url
+
+    url = generate_presigned_get_url("path/to/file.with.dots.mp4", expires_in=60)
+    assert "/path/to/file.with.dots.mp4?" in url
+
+
+def test_generate_presigned_get_url_rejects_invalid_expires_in():
+    """expires_in は AWS 仕様 (1-604800 秒) の範囲外で ValueError。"""
+    from app.storage import generate_presigned_get_url
+
+    with pytest.raises(ValueError):
+        generate_presigned_get_url("k", expires_in=0)
+    with pytest.raises(ValueError):
+        generate_presigned_get_url("k", expires_in=-1)
+    with pytest.raises(ValueError):
+        generate_presigned_get_url("k", expires_in=604801)

--- a/backend/tests/test_video_thumb_queue.py
+++ b/backend/tests/test_video_thumb_queue.py
@@ -159,7 +159,10 @@ async def test_process_local_generates_thumbnail(mock_valkey):
 
     with (
         patch("app.database.async_session", return_value=mock_session),
-        patch("app.storage.download_file", new_callable=AsyncMock) as mock_dl,
+        patch(
+            "app.storage.generate_presigned_get_url",
+            return_value="http://nekono3s:8080/nekonoverse/u/abc/test.mp4?X-Amz-Signature=abc",
+        ) as mock_presign,
         patch("app.storage.upload_file", new_callable=AsyncMock) as mock_ul,
         patch(
             "app.utils.http_client.make_video_thumb_client", return_value=mock_client
@@ -167,11 +170,17 @@ async def test_process_local_generates_thumbnail(mock_valkey):
         patch("app.services.video_thumb_queue.settings") as mock_settings,
     ):
         mock_settings.video_thumb_base_url = "http://video-thumb:8005"
-        mock_dl.return_value = b"video-data"
 
         await _process_local({"drive_file_id": str(uuid.uuid4())})
 
-    mock_dl.assert_called_once_with("u/abc/test.mp4")
+    # 動画は DL せず presigned URL を生成 → /thumbnail_from_url に JSON で渡す
+    mock_presign.assert_called_once_with("u/abc/test.mp4", expires_in=300)
+    mock_client.post.assert_called_once()
+    call_args, call_kwargs = mock_client.post.call_args
+    assert call_args[0] == "http://video-thumb:8005/thumbnail_from_url"
+    assert call_kwargs["json"] == {
+        "url": "http://nekono3s:8080/nekonoverse/u/abc/test.mp4?X-Amz-Signature=abc"
+    }
     mock_ul.assert_called_once_with("thumb/u/abc/test.mp4.webp", thumb_bytes, "image/webp")
     assert mock_file.thumbnail_s3_key == "thumb/u/abc/test.mp4.webp"
     assert mock_file.thumbnail_mime_type == "image/webp"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -345,6 +345,9 @@ services:
   #       chown 101:101 /var/run/video-thumb &&
   #       exec setpriv --reuid=101 --regid=101 --clear-groups \
   #         uvicorn main:app --uds /var/run/video-thumb/uvicorn.sock
+  #   environment:
+  #     # nekono3s が private IP に解決されるため /thumbnail_from_url で許可する
+  #     ALLOW_PRIVATE_URL: "1"
   #   volumes:
   #     - video_thumb_sock:/var/run/video-thumb
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -276,17 +276,13 @@ services:
   # Optional: media-proxy-rs (uncomment to use)
   # 画像変換専用。/transform POST のみ使用するため外部アクセス不要。
   # network_mode: "none" で TCP を無効化し UDS のみで通信。
+  # イメージは distroless ベース (shell / chown / su なし) なので、socket 用 named volume は
+  # tmpfs + uid/gid 指定で初回から 852 所有にし、コンテナ自体は 852 で直接起動する。
   # media-proxy-rs:
   #   image: ghcr.io/nekonoverse/media-proxy-rs:main
   #   restart: unless-stopped
   #   network_mode: "none"
-  #   user: "0:0"
-  #   command:
-  #     - sh
-  #     - -c
-  #     - |
-  #       chown 852:852 /var/run/media-proxy-rs &&
-  #       exec su -s /bin/sh proxy -c './media-proxy-rs'
+  #   user: "852:852"
   #   deploy:
   #     resources:
   #       limits:
@@ -428,7 +424,12 @@ volumes:
   # face-detect UDS 使用時はコメント解除
   # face_detect_sock:
   # media-proxy-rs UDS 使用時はコメント解除
+  # (distroless イメージは chown を持たないため tmpfs + uid/gid 指定で 852 所有を初期化する)
   # media_proxy_rs_sock:
+  #   driver_opts:
+  #     type: tmpfs
+  #     device: tmpfs
+  #     o: "uid=852,gid=852,mode=0770"
   # neko-vision UDS 使用時はコメント解除
   # neko_vision_sock:
   # video-thumb UDS 使用時はコメント解除

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -333,6 +333,10 @@ services:
   # Optional: Video thumbnail generation service (uncomment to use)
   # 動画のサムネイル生成 (FFmpeg + Pillow)。GPU 不要。
   # Also uncomment video_thumb_sock volume in app/worker service and VIDEO_THUMB_URL/UDS env vars.
+  # ⚠️ SECURITY NOTE
+  # ALLOW_PRIVATE_URL=1 はプライベート IP 宛 fetch を許可するため、video-thumb は
+  # **UDS のみで通信し外部ネットワーク露出ゼロ** で運用すること (`network_mode: "none"` 必須)。
+  # 内部メタデータエンドポイント等への SSRF 踏み台にならないよう境界を保つ。
   # video-thumb:
   #   image: ghcr.io/nekonoverse/video-thumb:latest
   #   restart: unless-stopped

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -258,6 +258,12 @@ services:
   # Optional: Video thumbnail generation service (uncomment to use)
   # 動画のサムネイル生成 (FFmpeg + Pillow)。GPU 不要。
   # Set VIDEO_THUMB_URL=http://video-thumb:8005 in app/worker environment.
+  #
+  # ⚠️ SECURITY NOTE
+  # ALLOW_PRIVATE_URL=1 を設定するとプライベート IP 宛 fetch が許可されるため、
+  # video-thumb は **backend / worker からのみ到達可能なネットワーク境界に配置すること**。
+  # ホスト直公開 (`ports: 8005:8005`) や同一 Docker network 上で他コンテナから直叩き可能な
+  # 構成にすると、内部メタデータエンドポイント等への SSRF 踏み台になる。
   # video-thumb:
   #   image: ghcr.io/nekonoverse/video-thumb:latest
   #   restart: unless-stopped

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -261,6 +261,9 @@ services:
   # video-thumb:
   #   image: ghcr.io/nekonoverse/video-thumb:latest
   #   restart: unless-stopped
+  #   environment:
+  #     # nekono3s が private IP に解決されるため /thumbnail_from_url で許可する
+  #     ALLOW_PRIVATE_URL: "1"
   #   expose:
   #     - "8005"
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260502-1",
+  "version": "20260504-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260502-1",
+      "version": "20260504-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260502-1",
+  "version": "20260504-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## パフォーマンス

- **動画サムネ生成を S3 presigned URL 渡しに切替** — backend が動画をフル DL せず presigned URL を JSON で video-thumb に投げる方式に変更。backend のメモリ使用量と帯域がほぼゼロになり、video-thumb 側も HTTP Range で先頭フレームのみ取得 → tempfile 不要化。大容量動画で大幅高速化 (#1013, #1014)

## 運用上の注意 (重要)

- 本リリースから **video-thumb イメージは `/thumbnail_from_url` 対応版が必須**。`docker compose pull` で video-thumb の最新イメージを取得すること
- video-thumb サービスの環境変数に **`ALLOW_PRIVATE_URL=1`** を追加する必要あり (nekono3s が private IP に解決されるため)。`docker-compose.yml.example` / `docker-compose.prod.yml` のサンプルに反映済み