### PR TITLE
fix: リリース 20260504-1 のレビュー指摘対応 (Major 1-2 + Minor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### 運用上の注意
 
 - 本リリースから video-thumb イメージは **`/thumbnail_from_url` 対応版が必須**。`docker compose pull` で video-thumb の最新イメージを取得すること。nekono3s が private IP に解決されるため、video-thumb サービスの環境変数に `ALLOW_PRIVATE_URL=1` を設定する必要あり (`docker-compose.yml.example` / `docker-compose.prod.yml` のサンプルに反映済み)
+- ⚠️ `ALLOW_PRIVATE_URL=1` はプライベート IP 宛 HTTP fetch を許可するため、video-thumb は **backend/worker からのみ到達可能なネットワーク境界** で運用すること (`docker-compose.prod.yml` の UDS 構成または同等の隔離)。サンプルコメントにも明記済み
+
+### インフラ
+
+- **`docker-compose.prod.yml` の `media-proxy-rs` UDS 設定例を distroless 対応に更新** — runtime image が distroless/static-debian13 化された ([nekonoverse/media-proxy-rs#6](https://github.com/nekonoverse/media-proxy-rs/pull/6)) ことに伴い、`sh -c "chown..."` パターンを廃止し socket volume を tmpfs + uid/gid 指定で初期化する形式に。コメントアウト済みブロックなので機能影響なし (#1011, #1012)
 
 ---
 

--- a/backend/app/services/video_thumb_queue.py
+++ b/backend/app/services/video_thumb_queue.py
@@ -25,7 +25,9 @@ DEAD_KEY = "video_thumb:dead"
 HEARTBEAT_KEY = "worker:video_thumb:heartbeat"
 
 MAX_ATTEMPTS = 5
-MAX_CONCURRENT = 2  # 動画処理はCPU/メモリ集約的
+# 動画は presigned URL を渡すだけで backend 側は CPU/メモリ集約的でないが、
+# video-thumb (FFmpeg) が同時並列処理できる本数の方が実質的な律速。デフォルトは保守的に 2 並列。
+MAX_CONCURRENT = 2
 
 _VIDEO_MIMES = {"video/mp4", "video/webm", "video/quicktime", "video/x-matroska"}
 
@@ -97,7 +99,7 @@ async def _process_local(job: dict) -> None:
 
         # S3 presigned URL を生成 (video-thumb はこの URL から HTTP Range で取得)。
         # 有効期限はサムネ生成 1 回分の処理時間に余裕を持たせて 5 分。リトライで遅延しても
-        # URL は `_process_local` 実行時に毎回再発行されるので、再 enqueue 時点で再生成される。
+        # URL は `_process_local` 再実行時に毎回再発行される。
         video_url = generate_presigned_get_url(drive_file.s3_key, expires_in=300)
 
         # video-thumb サービスに URL を渡す

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -193,7 +193,7 @@ def generate_presigned_get_url(key: str, expires_in: int = 300) -> str:
     """
     if not 1 <= expires_in <= 604800:
         raise ValueError(
-            f"expires_in must be between 1 and 604800 seconds, got {expires_in}"
+            f"expires_in は 1 〜 604800 秒の範囲で指定してください (got {expires_in})"
         )
     now = datetime.now(timezone.utc)
     date_str = now.strftime("%Y%m%d")
@@ -245,7 +245,9 @@ def generate_presigned_get_url(key: str, expires_in: int = 300) -> str:
         hashlib.sha256,
     ).hexdigest()
 
+    # endpoint URL に末尾スラッシュがあると `//bucket/key` になるため除去
+    endpoint = settings.s3_endpoint_url.rstrip("/")
     return (
-        f"{settings.s3_endpoint_url}{canonical_uri}"
+        f"{endpoint}{canonical_uri}"
         f"?{canonical_query}&X-Amz-Signature={signature}"
     )

--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -170,3 +170,19 @@ def test_generate_presigned_get_url_rejects_invalid_expires_in():
         generate_presigned_get_url("k", expires_in=-1)
     with pytest.raises(ValueError):
         generate_presigned_get_url("k", expires_in=604801)
+
+
+def test_generate_presigned_get_url_strips_trailing_slash():
+    """endpoint URL に末尾スラッシュがあっても `//bucket/key` にならない。"""
+    import app.storage
+    from app.storage import generate_presigned_get_url
+
+    # settings.s3_endpoint_url を一時的に末尾スラッシュ付きに
+    orig = app.storage.settings.s3_endpoint_url
+    try:
+        app.storage.settings.s3_endpoint_url = "http://nekono3s:8080/"
+        url = generate_presigned_get_url("test.mp4", expires_in=60)
+        assert url.startswith("http://nekono3s:8080/nekonoverse/test.mp4?")
+        assert "//nekonoverse" not in url
+    finally:
+        app.storage.settings.s3_endpoint_url = orig

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -333,6 +333,10 @@ services:
   # Optional: Video thumbnail generation service (uncomment to use)
   # 動画のサムネイル生成 (FFmpeg + Pillow)。GPU 不要。
   # Also uncomment video_thumb_sock volume in app/worker service and VIDEO_THUMB_URL/UDS env vars.
+  # ⚠️ SECURITY NOTE
+  # ALLOW_PRIVATE_URL=1 はプライベート IP 宛 fetch を許可するため、video-thumb は
+  # **UDS のみで通信し外部ネットワーク露出ゼロ** で運用すること (`network_mode: "none"` 必須)。
+  # 内部メタデータエンドポイント等への SSRF 踏み台にならないよう境界を保つ。
   # video-thumb:
   #   image: ghcr.io/nekonoverse/video-thumb:latest
   #   restart: unless-stopped

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -258,6 +258,12 @@ services:
   # Optional: Video thumbnail generation service (uncomment to use)
   # 動画のサムネイル生成 (FFmpeg + Pillow)。GPU 不要。
   # Set VIDEO_THUMB_URL=http://video-thumb:8005 in app/worker environment.
+  #
+  # ⚠️ SECURITY NOTE
+  # ALLOW_PRIVATE_URL=1 を設定するとプライベート IP 宛 fetch が許可されるため、
+  # video-thumb は **backend / worker からのみ到達可能なネットワーク境界に配置すること**。
+  # ホスト直公開 (`ports: 8005:8005`) や同一 Docker network 上で他コンテナから直叩き可能な
+  # 構成にすると、内部メタデータエンドポイント等への SSRF 踏み台になる。
   # video-thumb:
   #   image: ghcr.io/nekonoverse/video-thumb:latest
   #   restart: unless-stopped


### PR DESCRIPTION
[#1015](https://github.com/nekonoverse/nekonoverse/pull/1015) (Release 20260504-1) の nekonaudit レビュー指摘を反映。マージするとリリース PR の diff にも自動反映される。

## 取り込み

### 🟠 Major
- `video_thumb_queue.MAX_CONCURRENT` のコメントが古いままだったので、新事実 (backend は presigned URL を投げるだけで律速は video-thumb 側) に更新
- `ALLOW_PRIVATE_URL=1` の SSRF リスクを docker-compose 例と CHANGELOG に明示。「video-thumb は backend/worker からのみ到達可能なネットワーク境界に置く」前提を文書化

### 🟡 Minor
- video_thumb_queue.py のコメント表現「再 enqueue 時点」→「再実行時」(より正確)
- `expires_in` のバリデーションエラーメッセージを日本語化 (storage.py)
- `s3_endpoint_url.rstrip("/")` で末尾スラッシュ除去 (`//bucket/...` 破綻を防止)
- CHANGELOG に media-proxy-rs distroless 対応 (#1011/#1012) も追記

## フォロー

- 🟠 Major 3 (SigV4 署名仕様一致テスト) は実装コストが大きいため #1016 で別途追跡

## Test plan

- [x] `pytest tests/test_storage_extended.py tests/test_video_thumb_queue.py -v` 全 21 件 pass (新規 1 件)
- [ ] CI 通過