### PR TITLE
test: SigV4 署名が botocore (AWS 公式) と完全一致することを検証 (#1016)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,8 @@ dev = [
     "psycopg2-binary>=2.9.0",
     "httpx[socks]>=0.28.0",
     "ruff>=0.8.0",
+    # SigV4 presigned URL の自前実装が AWS 仕様と一致するか検証する参照実装として使う
+    "botocore>=1.35.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -197,8 +197,6 @@ def test_generate_presigned_get_url_signature_matches_botocore():
     バイト一致を確認する。署名アルゴリズム (canonical_request 構築 → string_to_sign →
     HMAC) のいずれかが破綻すると確実に落ちる。
     """
-    pytest.importorskip("botocore")
-
     from urllib.parse import parse_qs, urlparse
 
     from botocore.auth import S3SigV4QueryAuth
@@ -224,9 +222,11 @@ def test_generate_presigned_get_url_signature_matches_botocore():
         region_name=settings.s3_region,
         expires=300,
     )
+    # 自前実装の rstrip("/") 経路と path 構造を揃える (endpoint の末尾スラッシュ正規化)
+    endpoint = settings.s3_endpoint_url.rstrip("/")
     request = AWSRequest(
         method="GET",
-        url=f"{settings.s3_endpoint_url}/{settings.s3_bucket}/{key}",
+        url=f"{endpoint}/{settings.s3_bucket}/{key}",
     )
     request.context["timestamp"] = our_qs["X-Amz-Date"][0]
     auth.add_auth(request)

--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -186,3 +186,61 @@ def test_generate_presigned_get_url_strips_trailing_slash():
         assert "//nekonoverse" not in url
     finally:
         app.storage.settings.s3_endpoint_url = orig
+
+
+def test_generate_presigned_get_url_signature_matches_botocore():
+    """自前実装の署名が botocore (AWS 公式 SDK) の S3SigV4QueryAuth と一致する。
+
+    自前 SigV4 実装が AWS 仕様に追従していることを担保する回帰テスト (#1016)。
+    タイムスタンプ依存を排除するため、自前実装が生成した URL から X-Amz-Date を
+    抽出して botocore に同じ時刻で再署名させ、署名値を含む全クエリパラメータの
+    バイト一致を確認する。署名アルゴリズム (canonical_request 構築 → string_to_sign →
+    HMAC) のいずれかが破綻すると確実に落ちる。
+    """
+    pytest.importorskip("botocore")
+
+    from urllib.parse import parse_qs, urlparse
+
+    from botocore.auth import S3SigV4QueryAuth
+    from botocore.awsrequest import AWSRequest
+    from botocore.credentials import Credentials
+
+    from app.config import settings
+    from app.storage import generate_presigned_get_url
+
+    # 自前実装で URL を生成
+    key = "u/abc/test.mp4"
+    our_url = generate_presigned_get_url(key, expires_in=300)
+    our_qs = parse_qs(urlparse(our_url).query)
+
+    # 自前実装の X-Amz-Date を botocore の timestamp として注入
+    creds = Credentials(
+        access_key=settings.s3_access_key_id,
+        secret_key=settings.s3_secret_access_key,
+    )
+    auth = S3SigV4QueryAuth(
+        credentials=creds,
+        service_name="s3",
+        region_name=settings.s3_region,
+        expires=300,
+    )
+    request = AWSRequest(
+        method="GET",
+        url=f"{settings.s3_endpoint_url}/{settings.s3_bucket}/{key}",
+    )
+    request.context["timestamp"] = our_qs["X-Amz-Date"][0]
+    auth.add_auth(request)
+    ref_qs = parse_qs(urlparse(request.url).query)
+
+    # 全パラメータが完全一致 (署名アルゴリズム破綻時に確実に落ちる)
+    for param in (
+        "X-Amz-Algorithm",
+        "X-Amz-Credential",
+        "X-Amz-Date",
+        "X-Amz-Expires",
+        "X-Amz-SignedHeaders",
+        "X-Amz-Signature",
+    ):
+        assert our_qs[param] == ref_qs[param], (
+            f"{param} mismatch: ours={our_qs[param]!r} botocore={ref_qs[param]!r}"
+        )


### PR DESCRIPTION
Closes #1016

## 概要

#1015 nekonaudit Major 3 指摘への対応。自前 SigV4 実装 (`generate_presigned_get_url`) が AWS 仕様に追従していることを担保する回帰テストを追加。

## 実装方針

1. 自前実装で URL を生成
2. URL から `X-Amz-Date` を抽出
3. botocore の `S3SigV4QueryAuth` に同じタイムスタンプを `request.context['timestamp']` で注入して再署名
4. 全クエリパラメータ (Algorithm / Credential / Date / Expires / SignedHeaders / **Signature**) のバイト一致を確認

タイムスタンプを揃えることで、canonical_request 構築 → string_to_sign → HMAC のいずれかが破綻すると確実に落ちる構造。署名値そのものまで一致するので、AWS 仕様逸脱を未然に検出できる。

## 依存追加

- `botocore>=1.35.0` を **dev dependency** に追加 (本番依存への追加なし、テスト実行時のみ使用)

## Test plan

- [x] `pytest tests/test_storage_extended.py -v` 全 13 件 pass (新規 1 件)
- [ ] CI 通過