### PR TITLE
Release 20260504-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [20260504-2](https://github.com/nekonoverse/nekonoverse/releases/tag/20260504-2) — 2026-05-04
+
+### 観測性
+
+- **`/api/v1/instance` / `/api/v2/instance` の残存 `except Exception: pass` を logger 化** — settings batch / VAPID / 法的ページ / stats 等のサイレント故障を本番ログから検出可能に。Valkey cache の get/set 失敗は DB フォールバックで継続できる経路のため `logger.warning` (traceback なし) に降格してログ洪水を防止。`lifespan` 起動時の警告 4 箇所もモジュール logger に統一 (#1010, #1018)
+
+### テスト
+
+- **SigV4 presigned URL 署名が botocore (AWS 公式 SDK) と完全一致することを検証** — 自前 SigV4 実装が AWS 仕様に追従していることを担保する回帰テストを追加。タイムスタンプ依存を排除するため自前実装が生成した URL の `X-Amz-Date` を botocore に注入し、Signature を含む全クエリパラメータのバイト一致を確認。canonical_request 構築 → string_to_sign → HMAC のいずれかが破綻すると確実に落ちる (#1016, #1019)
+
+---
+
 ## [20260504-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260504-1) — 2026-05-04
 
 ### パフォーマンス

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260504-1"
+__version__ = "20260504-2"
 
 
 def _resolve_version() -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,9 @@
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI, HTTPException, Query
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_FAVICON_SVG = (
     b'<svg xmlns="http://www.w3.org/2000/svg"'
@@ -70,8 +73,6 @@ from app.dependencies import get_db, get_permitted_staff
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    import logging
-
     import httpx
 
     from app.storage import ensure_bucket
@@ -79,7 +80,7 @@ async def lifespan(app: FastAPI):
     try:
         await ensure_bucket()
     except Exception as e:
-        logging.getLogger(__name__).warning("Could not ensure S3 bucket: %s", e)
+        logger.warning("Could not ensure S3 bucket: %s", e)
 
     from app.config import settings as app_settings
     from app.utils.http_client import make_async_client
@@ -99,7 +100,7 @@ async def lifespan(app: FastAPI):
         async with async_session() as startup_db:
             await load_db_vapid_key_async(startup_db)
     except Exception as e:
-        logging.getLogger(__name__).warning("Could not load VAPID key: %s", e)
+        logger.warning("Could not load VAPID key: %s", e)
 
     # デフォルトサーバーアイコンの自動生成（初回起動時）
     try:
@@ -109,7 +110,7 @@ async def lifespan(app: FastAPI):
         async with _as() as icon_db:
             await ensure_default_icons(icon_db)
     except Exception as e:
-        logging.getLogger(__name__).warning("Could not ensure default icons: %s", e)
+        logger.warning("Could not ensure default icons: %s", e)
 
     # システムアカウントの自動作成
     try:
@@ -119,7 +120,7 @@ async def lifespan(app: FastAPI):
         async with _sa() as sys_db:
             await ensure_system_accounts(sys_db)
     except Exception as e:
-        logging.getLogger(__name__).warning("Could not ensure system accounts: %s", e)
+        logger.warning("Could not ensure system accounts: %s", e)
 
     from app.pubsub_hub import pubsub_hub
 
@@ -230,8 +231,9 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
         _cached = await _valkey.get(_cache_key)
         if _cached:
             return _json.loads(_cached)
-    except Exception:
-        pass
+    except Exception as e:
+        # Valkey down 時は DB から再生成して継続するため warning 止まり (traceback なし)
+        logger.warning("instance v1 cache get failed: %s", e)
 
     from sqlalchemy import func, select
 
@@ -277,7 +279,7 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
         if s.get("katex_enabled") == "true":
             katex_enabled = True
     except Exception:
-        pass
+        logger.exception("instance v1 settings batch failed")
 
     # サーバー統計を1クエリで取得（スカラーサブクエリ）
     user_count = 0
@@ -317,8 +319,7 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
         status_count = stats_row.statuses or 0
         domain_count = stats_row.domains or 0
     except Exception:
-        import logging
-        logging.getLogger(__name__).exception("instance v1 stats query failed")
+        logger.exception("instance v1 stats query failed")
 
     # VAPID公開鍵 (Web Push用、push_enabledの場合のみ)
     vapid_key = None
@@ -328,7 +329,7 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
         if await is_push_enabled(db):
             vapid_key = get_vapid_public_key_base64url()
     except Exception:
-        pass
+        logger.exception("instance v1 vapid key load failed")
 
     contact_info = await _build_contact(db)
 
@@ -403,12 +404,13 @@ async def instance_info(db: AsyncSession = Depends(get_db)):
         if s.get("privacy_policy"):
             resp["privacy_policy_url"] = f"https://{settings.domain}/privacy"
     except Exception:
-        pass
+        logger.exception("instance v1 legal page URL build failed")
 
     try:
         await _valkey.set(_cache_key, _json.dumps(resp), ex=120)
-    except Exception:
-        pass
+    except Exception as e:
+        # キャッシュ書き込み失敗してもレスポンス自体は正常なので warning 止まり
+        logger.warning("instance v1 cache set failed: %s", e)
 
     return resp
 
@@ -425,8 +427,9 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
         _cached2 = await _valkey2.get(_cache_key2)
         if _cached2:
             return _json2.loads(_cached2)
-    except Exception:
-        pass
+    except Exception as e:
+        # Valkey down 時は DB から再生成して継続するため warning 止まり
+        logger.warning("instance v2 cache get failed: %s", e)
 
     from sqlalchemy import func, select
 
@@ -465,7 +468,7 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
         if s.get("katex_enabled") == "true":
             katex_enabled = True
     except Exception:
-        pass
+        logger.exception("instance v2 settings batch failed")
 
     user_count = 0
     try:
@@ -477,8 +480,7 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
         )
         user_count = user_result.scalar() or 0
     except Exception:
-        import logging
-        logging.getLogger(__name__).exception("instance v2 user_count query failed")
+        logger.exception("instance v2 user_count query failed")
 
     vapid_key = None
     try:
@@ -487,7 +489,7 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
         if await is_push_enabled(db):
             vapid_key = get_vapid_public_key_base64url()
     except Exception:
-        pass
+        logger.exception("instance v2 vapid key load failed")
 
     contact_info = await _build_contact(db)
 
@@ -573,8 +575,9 @@ async def instance_info_v2(db: AsyncSession = Depends(get_db)):
 
     try:
         await _valkey2.set(_cache_key2, _json2.dumps(resp), ex=120)
-    except Exception:
-        pass
+    except Exception as e:
+        # キャッシュ書き込み失敗してもレスポンス自体は正常なので warning 止まり
+        logger.warning("instance v2 cache set failed: %s", e)
 
     return resp
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260504-1"
+version = "20260504-2"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,8 @@ dev = [
     "psycopg2-binary>=2.9.0",
     "httpx[socks]>=0.28.0",
     "ruff>=0.8.0",
+    # SigV4 presigned URL の自前実装が AWS 仕様と一致するか検証する参照実装として使う
+    "botocore>=1.35.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -186,3 +186,61 @@ def test_generate_presigned_get_url_strips_trailing_slash():
         assert "//nekonoverse" not in url
     finally:
         app.storage.settings.s3_endpoint_url = orig
+
+
+def test_generate_presigned_get_url_signature_matches_botocore():
+    """自前実装の署名が botocore (AWS 公式 SDK) の S3SigV4QueryAuth と一致する。
+
+    自前 SigV4 実装が AWS 仕様に追従していることを担保する回帰テスト (#1016)。
+    タイムスタンプ依存を排除するため、自前実装が生成した URL から X-Amz-Date を
+    抽出して botocore に同じ時刻で再署名させ、署名値を含む全クエリパラメータの
+    バイト一致を確認する。署名アルゴリズム (canonical_request 構築 → string_to_sign →
+    HMAC) のいずれかが破綻すると確実に落ちる。
+    """
+    from urllib.parse import parse_qs, urlparse
+
+    from botocore.auth import S3SigV4QueryAuth
+    from botocore.awsrequest import AWSRequest
+    from botocore.credentials import Credentials
+
+    from app.config import settings
+    from app.storage import generate_presigned_get_url
+
+    # 自前実装で URL を生成
+    key = "u/abc/test.mp4"
+    our_url = generate_presigned_get_url(key, expires_in=300)
+    our_qs = parse_qs(urlparse(our_url).query)
+
+    # 自前実装の X-Amz-Date を botocore の timestamp として注入
+    creds = Credentials(
+        access_key=settings.s3_access_key_id,
+        secret_key=settings.s3_secret_access_key,
+    )
+    auth = S3SigV4QueryAuth(
+        credentials=creds,
+        service_name="s3",
+        region_name=settings.s3_region,
+        expires=300,
+    )
+    # 自前実装の rstrip("/") 経路と path 構造を揃える (endpoint の末尾スラッシュ正規化)
+    endpoint = settings.s3_endpoint_url.rstrip("/")
+    request = AWSRequest(
+        method="GET",
+        url=f"{endpoint}/{settings.s3_bucket}/{key}",
+    )
+    request.context["timestamp"] = our_qs["X-Amz-Date"][0]
+    auth.add_auth(request)
+    ref_qs = parse_qs(urlparse(request.url).query)
+
+    # 全パラメータが完全一致 (署名アルゴリズム破綻時に確実に落ちる)
+    for param in (
+        "X-Amz-Algorithm",
+        "X-Amz-Credential",
+        "X-Amz-Date",
+        "X-Amz-Expires",
+        "X-Amz-SignedHeaders",
+        "X-Amz-Signature",
+    ):
+        assert our_qs[param] == ref_qs[param], (
+            f"{param} mismatch: ours={our_qs[param]!r} botocore={ref_qs[param]!r}"
+        )

--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -188,7 +188,23 @@ def test_generate_presigned_get_url_strips_trailing_slash():
         app.storage.settings.s3_endpoint_url = orig
 
 
-def test_generate_presigned_get_url_signature_matches_botocore():
+@pytest.mark.parametrize(
+    "key",
+    [
+        # 通常 (UUID 由来の S3 キー)
+        "u/abc/test.mp4",
+        # スペースを含む (URL では %20 にエンコード必須)
+        "path with space/file.mp4",
+        # `+` を含む (URL では %2B にエンコード必須、空白と混同されやすい)
+        "a+b/file.mp4",
+        # 非 ASCII (UTF-8 マルチバイト)
+        "日本語/file.mp4",
+        # `~` `_` `-` `.` (RFC 3986 unreserved、ノーエンコード)
+        "u/abc/foo~bar_baz-qux.mp4",
+    ],
+    ids=["ascii", "space", "plus", "utf8", "unreserved"],
+)
+def test_generate_presigned_get_url_signature_matches_botocore(key):
     """自前実装の署名が botocore (AWS 公式 SDK) の S3SigV4QueryAuth と一致する。
 
     自前 SigV4 実装が AWS 仕様に追従していることを担保する回帰テスト (#1016)。
@@ -196,8 +212,11 @@ def test_generate_presigned_get_url_signature_matches_botocore():
     抽出して botocore に同じ時刻で再署名させ、署名値を含む全クエリパラメータの
     バイト一致を確認する。署名アルゴリズム (canonical_request 構築 → string_to_sign →
     HMAC) のいずれかが破綻すると確実に落ちる。
+
+    parametrize で複数の key 形 (ASCII / スペース / `+` / 非 ASCII / unreserved
+    記号) を投入し、URL エンコード経路の差異も拾う。
     """
-    from urllib.parse import parse_qs, urlparse
+    from urllib.parse import parse_qs, quote, urlparse
 
     from botocore.auth import S3SigV4QueryAuth
     from botocore.awsrequest import AWSRequest
@@ -207,7 +226,6 @@ def test_generate_presigned_get_url_signature_matches_botocore():
     from app.storage import generate_presigned_get_url
 
     # 自前実装で URL を生成
-    key = "u/abc/test.mp4"
     our_url = generate_presigned_get_url(key, expires_in=300)
     our_qs = parse_qs(urlparse(our_url).query)
 
@@ -222,11 +240,16 @@ def test_generate_presigned_get_url_signature_matches_botocore():
         region_name=settings.s3_region,
         expires=300,
     )
-    # 自前実装の rstrip("/") 経路と path 構造を揃える (endpoint の末尾スラッシュ正規化)
+    # 自前実装の rstrip("/") 経路と path 構造を揃える (endpoint の末尾スラッシュ正規化)。
+    # botocore の S3 canonical_uri は AWSRequest.url の path をそのまま使うため、
+    # 自前実装と同じ encode 形式 (`quote(key, safe="/")`) で path を事前構築して渡す。
+    # こうしないと botocore が literal space や非 ASCII 文字を canonical に含めてしまい、
+    # 実際の HTTP wire 形式 (%-encoded) と乖離して署名一致を判定できない。
     endpoint = settings.s3_endpoint_url.rstrip("/")
+    encoded_key = quote(key, safe="/")
     request = AWSRequest(
         method="GET",
-        url=f"{endpoint}/{settings.s3_bucket}/{key}",
+        url=f"{endpoint}/{settings.s3_bucket}/{encoded_key}",
     )
     request.context["timestamp"] = our_qs["X-Amz-Date"][0]
     auth.add_auth(request)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260504-1",
+  "version": "20260504-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260504-1",
+      "version": "20260504-2",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260504-1",
+  "version": "20260504-2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 観測性

- **`/api/v1/instance` / `/api/v2/instance` の残存 `except Exception: pass` を logger 化** — settings batch / VAPID / 法的ページ / stats 等のサイレント故障を本番ログから検出可能に。Valkey cache の get/set 失敗は DB フォールバックで継続できる経路のため `logger.warning` (traceback なし) に降格してログ洪水を防止。`lifespan` 起動時の警告 4 箇所もモジュール logger に統一 (#1010, #1018)

## テスト

- **SigV4 presigned URL 署名が botocore (AWS 公式 SDK) と完全一致することを検証** — 自前 SigV4 実装が AWS 仕様に追従していることを担保する回帰テストを追加。タイムスタンプ依存を排除するため自前実装が生成した URL の `X-Amz-Date` を botocore に注入し、Signature を含む全クエリパラメータのバイト一致を確認。canonical_request 構築 → string_to_sign → HMAC のいずれかが破綻すると確実に落ちる (#1016, #1019)