### PR TITLE
test: SigV4 botocore 一致テストを URL エンコード経路の parametrize で強化

### DIFF
--- a/backend/tests/test_storage_extended.py
+++ b/backend/tests/test_storage_extended.py
@@ -188,7 +188,23 @@ def test_generate_presigned_get_url_strips_trailing_slash():
         app.storage.settings.s3_endpoint_url = orig
 
 
-def test_generate_presigned_get_url_signature_matches_botocore():
+@pytest.mark.parametrize(
+    "key",
+    [
+        # 通常 (UUID 由来の S3 キー)
+        "u/abc/test.mp4",
+        # スペースを含む (URL では %20 にエンコード必須)
+        "path with space/file.mp4",
+        # `+` を含む (URL では %2B にエンコード必須、空白と混同されやすい)
+        "a+b/file.mp4",
+        # 非 ASCII (UTF-8 マルチバイト)
+        "日本語/file.mp4",
+        # `~` `_` `-` `.` (RFC 3986 unreserved、ノーエンコード)
+        "u/abc/foo~bar_baz-qux.mp4",
+    ],
+    ids=["ascii", "space", "plus", "utf8", "unreserved"],
+)
+def test_generate_presigned_get_url_signature_matches_botocore(key):
     """自前実装の署名が botocore (AWS 公式 SDK) の S3SigV4QueryAuth と一致する。
 
     自前 SigV4 実装が AWS 仕様に追従していることを担保する回帰テスト (#1016)。
@@ -196,8 +212,11 @@ def test_generate_presigned_get_url_signature_matches_botocore():
     抽出して botocore に同じ時刻で再署名させ、署名値を含む全クエリパラメータの
     バイト一致を確認する。署名アルゴリズム (canonical_request 構築 → string_to_sign →
     HMAC) のいずれかが破綻すると確実に落ちる。
+
+    parametrize で複数の key 形 (ASCII / スペース / `+` / 非 ASCII / unreserved
+    記号) を投入し、URL エンコード経路の差異も拾う。
     """
-    from urllib.parse import parse_qs, urlparse
+    from urllib.parse import parse_qs, quote, urlparse
 
     from botocore.auth import S3SigV4QueryAuth
     from botocore.awsrequest import AWSRequest
@@ -207,7 +226,6 @@ def test_generate_presigned_get_url_signature_matches_botocore():
     from app.storage import generate_presigned_get_url
 
     # 自前実装で URL を生成
-    key = "u/abc/test.mp4"
     our_url = generate_presigned_get_url(key, expires_in=300)
     our_qs = parse_qs(urlparse(our_url).query)
 
@@ -222,11 +240,16 @@ def test_generate_presigned_get_url_signature_matches_botocore():
         region_name=settings.s3_region,
         expires=300,
     )
-    # 自前実装の rstrip("/") 経路と path 構造を揃える (endpoint の末尾スラッシュ正規化)
+    # 自前実装の rstrip("/") 経路と path 構造を揃える (endpoint の末尾スラッシュ正規化)。
+    # botocore の S3 canonical_uri は AWSRequest.url の path をそのまま使うため、
+    # 自前実装と同じ encode 形式 (`quote(key, safe="/")`) で path を事前構築して渡す。
+    # こうしないと botocore が literal space や非 ASCII 文字を canonical に含めてしまい、
+    # 実際の HTTP wire 形式 (%-encoded) と乖離して署名一致を判定できない。
     endpoint = settings.s3_endpoint_url.rstrip("/")
+    encoded_key = quote(key, safe="/")
     request = AWSRequest(
         method="GET",
-        url=f"{endpoint}/{settings.s3_bucket}/{key}",
+        url=f"{endpoint}/{settings.s3_bucket}/{encoded_key}",
     )
     request.context["timestamp"] = our_qs["X-Amz-Date"][0]
     auth.add_auth(request)


### PR DESCRIPTION
[#1020](https://github.com/nekonoverse/nekonoverse/pull/1020) (Release 20260504-2) の nekonaudit Minor 1 への対応。マージするとリリース PR の diff にも自動反映される。

## 概要

元の SigV4 botocore 一致テストは ASCII 安全文字 (`u/abc/test.mp4`) のみで、URL エンコードが必要な文字 (space, `+`, 非 ASCII 等) での一致を検証していなかった。`parametrize` で 5 ケース投入し、URL エンコード経路の差異も拾う。

## 投入ケース

| id | key | encoded form |
|---|---|---|
| ascii | `u/abc/test.mp4` | (encode 不要) |
| space | `path with space/file.mp4` | `path%20with%20space/file.mp4` |
| plus | `a+b/file.mp4` | `a%2Bb/file.mp4` |
| utf8 | `日本語/file.mp4` | `%E6%97%A5%E6%9C%AC%E8%AA%9E/file.mp4` |
| unreserved | `u/abc/foo~bar_baz-qux.mp4` | (RFC 3986 ノーエンコード) |

## 副次的修正

検証中に `botocore` の挙動を理解した結果、テスト側で 1 点修正:

- botocore の S3 canonical_uri は `AWSRequest.url` の path をそのまま使うため、literal space や非 ASCII を渡すと実際の HTTP wire 形式 (%-encoded) と乖離してしまう
- 自前実装と同じ encode 形式 (`quote(key, safe="/")`) で AWSRequest.url を事前構築して渡す形に修正
- これにより 5 ケース全てで完全一致を確認

## Test plan

- [x] `pytest tests/test_storage_extended.py::test_generate_presigned_get_url_signature_matches_botocore -v` 5/5 pass
- [ ] CI 通過