### PR TITLE
fix: detect-focal-points で未検出 (NULL) 画像を処理対象に含める (#1022)

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -148,10 +148,15 @@ async def _detect_focal_points(args: argparse.Namespace) -> None:
     # --- ローカル DriveFile ---
     # 検出が必要な画像を検索: バージョン NULL (未チェック) または古いバージョン
     # スキップ: 手動フォーカルポイント、現在のバージョンでチェック済み
+    # 注意: SQL の `column != 'manual'` は column IS NULL の行で NULL (=UNKNOWN) を返し
+    # WHERE で除外される三値論理問題があるため、IS NULL を or_ で明示的に許可する。
     async with async_session() as db:
         conditions = [
             DriveFile.mime_type.startswith("image/"),
-            DriveFile.focal_detect_version != "manual",
+            or_(
+                DriveFile.focal_detect_version.is_(None),
+                DriveFile.focal_detect_version != "manual",
+            ),
         ]
         if detect_version:
             conditions.append(
@@ -203,12 +208,16 @@ async def _detect_focal_points(args: argparse.Namespace) -> None:
         print()
 
     # --- リモート NoteAttachment ---
+    # SQL の三値論理問題は DriveFile 側と同じ。focal_detect_version IS NULL を or_ で明示。
     image_mimes = {"image/jpeg", "image/png", "image/webp", "image/gif", "image/avif", "image/apng"}
     async with async_session() as db:
         conditions = [
             NoteAttachment.remote_url.isnot(None),
             NoteAttachment.remote_mime_type.in_(image_mimes),
-            NoteAttachment.focal_detect_version != "manual",
+            or_(
+                NoteAttachment.focal_detect_version.is_(None),
+                NoteAttachment.focal_detect_version != "manual",
+            ),
         ]
         if detect_version:
             conditions.append(

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -119,8 +119,67 @@ async def _create_admin(args: argparse.Namespace) -> None:
     await engine.dispose()
 
 
+def _drive_file_pending_focal_conditions(detect_version: str | None) -> list:
+    """`detect-focal-points` で処理対象とする DriveFile の WHERE 条件リストを返す。
+
+    SQL の三値論理 (NULL != 'manual' は NULL = UNKNOWN → WHERE で除外) を回避するため
+    `IS NULL` を or_ で明示的に許可する。実装とテストで共用するために関数化。
+    """
+    from sqlalchemy import or_
+
+    from app.models.drive_file import DriveFile
+
+    conditions = [
+        DriveFile.mime_type.startswith("image/"),
+        or_(
+            DriveFile.focal_detect_version.is_(None),
+            DriveFile.focal_detect_version != "manual",
+        ),
+    ]
+    if detect_version:
+        conditions.append(
+            or_(
+                DriveFile.focal_detect_version.is_(None),
+                DriveFile.focal_detect_version != detect_version,
+            )
+        )
+    else:
+        conditions.append(DriveFile.focal_detect_version.is_(None))
+    return conditions
+
+
+def _note_attachment_pending_focal_conditions(detect_version: str | None) -> list:
+    """`detect-focal-points` で処理対象とする NoteAttachment の WHERE 条件リストを返す。
+
+    DriveFile 側と同じ三値論理問題への対処を含む。
+    """
+    from sqlalchemy import or_
+
+    from app.models.note_attachment import NoteAttachment
+
+    image_mimes = {"image/jpeg", "image/png", "image/webp", "image/gif", "image/avif", "image/apng"}
+    conditions = [
+        NoteAttachment.remote_url.isnot(None),
+        NoteAttachment.remote_mime_type.in_(image_mimes),
+        or_(
+            NoteAttachment.focal_detect_version.is_(None),
+            NoteAttachment.focal_detect_version != "manual",
+        ),
+    ]
+    if detect_version:
+        conditions.append(
+            or_(
+                NoteAttachment.focal_detect_version.is_(None),
+                NoteAttachment.focal_detect_version != detect_version,
+            )
+        )
+    else:
+        conditions.append(NoteAttachment.focal_detect_version.is_(None))
+    return conditions
+
+
 async def _detect_focal_points(args: argparse.Namespace) -> None:
-    from sqlalchemy import or_, select
+    from sqlalchemy import select
 
     from app.config import settings
     from app.models.drive_file import DriveFile
@@ -148,26 +207,8 @@ async def _detect_focal_points(args: argparse.Namespace) -> None:
     # --- ローカル DriveFile ---
     # 検出が必要な画像を検索: バージョン NULL (未チェック) または古いバージョン
     # スキップ: 手動フォーカルポイント、現在のバージョンでチェック済み
-    # 注意: SQL の `column != 'manual'` は column IS NULL の行で NULL (=UNKNOWN) を返し
-    # WHERE で除外される三値論理問題があるため、IS NULL を or_ で明示的に許可する。
     async with async_session() as db:
-        conditions = [
-            DriveFile.mime_type.startswith("image/"),
-            or_(
-                DriveFile.focal_detect_version.is_(None),
-                DriveFile.focal_detect_version != "manual",
-            ),
-        ]
-        if detect_version:
-            conditions.append(
-                or_(
-                    DriveFile.focal_detect_version.is_(None),
-                    DriveFile.focal_detect_version != detect_version,
-                )
-            )
-        else:
-            conditions.append(DriveFile.focal_detect_version.is_(None))
-
+        conditions = _drive_file_pending_focal_conditions(detect_version)
         rows = await db.execute(select(DriveFile).where(*conditions))
         local_files = list(rows.scalars().all())
 
@@ -208,27 +249,8 @@ async def _detect_focal_points(args: argparse.Namespace) -> None:
         print()
 
     # --- リモート NoteAttachment ---
-    # SQL の三値論理問題は DriveFile 側と同じ。focal_detect_version IS NULL を or_ で明示。
-    image_mimes = {"image/jpeg", "image/png", "image/webp", "image/gif", "image/avif", "image/apng"}
     async with async_session() as db:
-        conditions = [
-            NoteAttachment.remote_url.isnot(None),
-            NoteAttachment.remote_mime_type.in_(image_mimes),
-            or_(
-                NoteAttachment.focal_detect_version.is_(None),
-                NoteAttachment.focal_detect_version != "manual",
-            ),
-        ]
-        if detect_version:
-            conditions.append(
-                or_(
-                    NoteAttachment.focal_detect_version.is_(None),
-                    NoteAttachment.focal_detect_version != detect_version,
-                )
-            )
-        else:
-            conditions.append(NoteAttachment.focal_detect_version.is_(None))
-
+        conditions = _note_attachment_pending_focal_conditions(detect_version)
         rows = await db.execute(select(NoteAttachment).where(*conditions))
         remote_atts = list(rows.scalars().all())
 

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -200,8 +200,9 @@ async def test_detect_focal_points_query_includes_null_version_rows(db, test_use
     WHERE で除外される三値論理問題があるため、IS NULL を or_ で明示的に許可する必要がある。
     バグがある状態だと未検出 (NULL) の画像がそもそも処理対象に入らない。
     """
-    from sqlalchemy import or_, select
+    from sqlalchemy import select
 
+    from app.cli import _drive_file_pending_focal_conditions
     from app.models.drive_file import DriveFile
 
     # NULL 版の画像 (まだ検出されていない)
@@ -243,19 +244,8 @@ async def test_detect_focal_points_query_includes_null_version_rows(db, test_use
     db.add_all([df_null, df_manual, df_old, df_current])
     await db.commit()
 
-    # CLI と同じ WHERE 条件を再現
-    detect_version = "current-version-2"
-    conditions = [
-        DriveFile.mime_type.startswith("image/"),
-        or_(
-            DriveFile.focal_detect_version.is_(None),
-            DriveFile.focal_detect_version != "manual",
-        ),
-        or_(
-            DriveFile.focal_detect_version.is_(None),
-            DriveFile.focal_detect_version != detect_version,
-        ),
-    ]
+    # CLI 実装側のヘルパを呼び出して WHERE 条件を取得 (実装が変わればテストも追従)
+    conditions = _drive_file_pending_focal_conditions("current-version-2")
     rows = await db.execute(select(DriveFile).where(*conditions))
     target_ids = {r.id for r in rows.scalars().all()}
 
@@ -264,3 +254,45 @@ async def test_detect_focal_points_query_includes_null_version_rows(db, test_use
     assert df_old.id in target_ids
     assert df_manual.id not in target_ids
     assert df_current.id not in target_ids
+
+
+async def test_detect_focal_points_note_attachment_includes_null_version_rows(db, test_user, mock_valkey):
+    """NoteAttachment 側も同じ三値論理問題から守られていることの回帰テスト (#1022)。
+
+    DriveFile 側と対称な NULL 行除外バグが NoteAttachment 側にも存在していたため、
+    片肺修正ではなく両系列でテストカバーする。
+    """
+    from sqlalchemy import select
+
+    from tests.conftest import make_note
+
+    from app.cli import _note_attachment_pending_focal_conditions
+    from app.models.note_attachment import NoteAttachment
+
+    # NoteAttachment は note_id FK 必須なので Note を 1 件用意
+    actor_id = test_user.actor_id
+    from app.models.actor import Actor
+    actor = (await db.execute(select(Actor).where(Actor.id == actor_id))).scalar_one()
+    note = await make_note(db, actor)
+    await db.commit()
+
+    common = {
+        "note_id": note.id,
+        "remote_url": "https://remote.example/img.png",
+        "remote_mime_type": "image/png",
+    }
+    att_null = NoteAttachment(**common, position=0, focal_detect_version=None)
+    att_manual = NoteAttachment(**common, position=1, focal_detect_version="manual")
+    att_old = NoteAttachment(**common, position=2, focal_detect_version="old-1")
+    att_current = NoteAttachment(**common, position=3, focal_detect_version="current-2")
+    db.add_all([att_null, att_manual, att_old, att_current])
+    await db.commit()
+
+    conditions = _note_attachment_pending_focal_conditions("current-2")
+    rows = await db.execute(select(NoteAttachment).where(*conditions))
+    target_ids = {r.id for r in rows.scalars().all()}
+
+    assert att_null.id in target_ids, "NULL 版が処理対象に含まれていない (三値論理バグの再発)"
+    assert att_old.id in target_ids
+    assert att_manual.id not in target_ids
+    assert att_current.id not in target_ids

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import sys
+import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -187,3 +188,79 @@ def test_main_reset_password_calls_async(monkeypatch):
     mock_run.assert_called_once()
     coro = mock_run.call_args[0][0]
     coro.close()
+
+
+# ── _detect_focal_points: SQL 三値論理回帰 ──
+
+
+async def test_detect_focal_points_query_includes_null_version_rows(db, test_user, mock_valkey):
+    """focal_detect_version IS NULL の DriveFile が `!= 'manual'` フィルタで除外されないこと (#1022 回帰)。
+
+    SQL の `column != 'manual'` は column IS NULL の行で NULL (=UNKNOWN) を返し
+    WHERE で除外される三値論理問題があるため、IS NULL を or_ で明示的に許可する必要がある。
+    バグがある状態だと未検出 (NULL) の画像がそもそも処理対象に入らない。
+    """
+    from sqlalchemy import or_, select
+
+    from app.models.drive_file import DriveFile
+
+    # NULL 版の画像 (まだ検出されていない)
+    df_null = DriveFile(
+        owner_id=test_user.id,
+        s3_key=f"uploads/{uuid.uuid4().hex}/null.png",
+        filename="null.png",
+        mime_type="image/png",
+        size_bytes=1024,
+        focal_detect_version=None,
+    )
+    # manual 版の画像 (除外されるべき)
+    df_manual = DriveFile(
+        owner_id=test_user.id,
+        s3_key=f"uploads/{uuid.uuid4().hex}/manual.png",
+        filename="manual.png",
+        mime_type="image/png",
+        size_bytes=1024,
+        focal_detect_version="manual",
+    )
+    # 旧バージョン (再検出対象)
+    df_old = DriveFile(
+        owner_id=test_user.id,
+        s3_key=f"uploads/{uuid.uuid4().hex}/old.png",
+        filename="old.png",
+        mime_type="image/png",
+        size_bytes=1024,
+        focal_detect_version="old-version-1",
+    )
+    # 現バージョン (スキップ)
+    df_current = DriveFile(
+        owner_id=test_user.id,
+        s3_key=f"uploads/{uuid.uuid4().hex}/current.png",
+        filename="current.png",
+        mime_type="image/png",
+        size_bytes=1024,
+        focal_detect_version="current-version-2",
+    )
+    db.add_all([df_null, df_manual, df_old, df_current])
+    await db.commit()
+
+    # CLI と同じ WHERE 条件を再現
+    detect_version = "current-version-2"
+    conditions = [
+        DriveFile.mime_type.startswith("image/"),
+        or_(
+            DriveFile.focal_detect_version.is_(None),
+            DriveFile.focal_detect_version != "manual",
+        ),
+        or_(
+            DriveFile.focal_detect_version.is_(None),
+            DriveFile.focal_detect_version != detect_version,
+        ),
+    ]
+    rows = await db.execute(select(DriveFile).where(*conditions))
+    target_ids = {r.id for r in rows.scalars().all()}
+
+    # NULL と old は対象、manual と current は除外
+    assert df_null.id in target_ids, "NULL 版が処理対象に含まれていない (三値論理バグの再発)"
+    assert df_old.id in target_ids
+    assert df_manual.id not in target_ids
+    assert df_current.id not in target_ids


### PR DESCRIPTION
Closes #1022

## 概要

\`app.cli detect-focal-points\` を実行しても、未検出 (\`focal_detect_version IS NULL\`) の画像に判定がかからないバグの修正。

## 原因

SQL の三値論理: \`column != 'manual'\` は \`column IS NULL\` の行で **NULL (=UNKNOWN) を返し WHERE で除外される**。

\`\`\`python
# Before (バグ): NULL 版が WHERE で落ちる
DriveFile.focal_detect_version != "manual"
\`\`\`

Python の \`None != "manual"\` が \`True\` なのと挙動が異なる罠。DriveFile / NoteAttachment 両方に同じバグがあった。

## 修正

\`\`\`python
# After: NULL を明示的に許可
or_(
    DriveFile.focal_detect_version.is_(None),
    DriveFile.focal_detect_version != "manual",
)
\`\`\`

## 回帰テスト

\`test_detect_focal_points_query_includes_null_version_rows\`: NULL / manual / 旧 / 現バージョンの DriveFile を投入し、CLI と同じ WHERE 条件で:
- NULL → 含まれる
- manual → 除外
- 旧バージョン → 含まれる
- 現バージョン → 除外

を assert。バグがある状態だと NULL が含まれずに落ちる。

## Test plan

- [x] \`pytest tests/test_cli.py -v\` 全 11 件 pass (新規 1 件)
- [ ] CI 通過
- [ ] 本番で \`detect-focal-points\` 実行 → NULL 画像が処理されることを確認