### PR TITLE
ci: pip-audit で pip 自身を upgrade (CVE-2026-6357 対応)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      # pip 自身の CVE (CVE-2026-3219 / CVE-2026-6357 など) を吸収するため最新へ upgrade
+      - run: pip install --upgrade pip
       - run: pip install pip-audit
       - run: pip install -e backend/
       - run: |


### PR DESCRIPTION
## 概要

`pip 26.0.1` に CVE-2026-6357 が新規報告され、修正版 26.1 が出ているため pip-audit ジョブで `pip install --upgrade pip` を追加。これにより Dependabot PR (#1025/#1026) の pip-audit 失敗を解消。

## Test plan

- [ ] CI 通過 (pip-audit で 0 vuln になるはず)