### PR TITLE
fix(deps): fast-uri を 3.1.2 に更新

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4068,9 +4068,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- frontend の dev 依存 (transitive: vitest → ajv → fast-uri) を 3.1.0 → 3.1.2 に更新
- CVE-2026-6321 / GHSA-q3j6-qgpj-74h6 の対応
- lockfile のみ更新 (package.json は変更なし)

## Test plan

- [x] `npm install --package-lock-only` で lockfile が変更されることを確認
- [x] package.json に変更がないことを確認
- [ ] CI のフロントエンドビルド・テストがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)