### PR TITLE
fix(deps): @babel/plugin-transform-modules-systemjs を 7.29.4 に更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### セキュリティ
 
 - **fast-uri 3.1.0 → 3.1.2** — CVE-2026-6321 / GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments, HIGH) の修正取り込み。frontend の dev 依存 (vitest 経由 ajv) の transitive dep のため lockfile のみ更新 (#1029)
+- **@babel/plugin-transform-modules-systemjs 7.29.0 → 7.29.4** — GHSA 系 (HIGH, arbitrary code generation when compiling malicious input) の修正取り込み。frontend の dev 依存 (vite 経由) の transitive dep のため lockfile のみ更新
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- frontend の dev 依存 (transitive: vite → babel) を 7.29.0 → 7.29.4 に更新
- GHSA (HIGH, arbitrary code generation when compiling malicious input) の対応
- lockfile のみ更新 (package.json は変更なし)
- 20260509-1 リリースに含めるため CHANGELOG にも追記

## Test plan

- [x] `npm install --package-lock-only` で lockfile が変更されることを確認
- [x] package.json に変更がないことを確認
- [ ] CI のフロントエンドビルド・テストがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)