### PR TITLE
Release 20260509-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [20260509-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260509-1) — 2026-05-09
+
+### セキュリティ
+
+- **fast-uri 3.1.0 → 3.1.2** — CVE-2026-6321 / GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments, HIGH) の修正取り込み。frontend の dev 依存 (vitest 経由 ajv) の transitive dep のため lockfile のみ更新 (#1029)
+
+---
+
 ## [20260507-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260507-1) — 2026-05-07
 
 ### セキュリティ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### セキュリティ
 
 - **fast-uri 3.1.0 → 3.1.2** — CVE-2026-6321 / GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments, HIGH) の修正取り込み。frontend の dev 依存 (vitest 経由 ajv) の transitive dep のため lockfile のみ更新 (#1029)
+- **@babel/plugin-transform-modules-systemjs 7.29.0 → 7.29.4** — GHSA 系 (HIGH, arbitrary code generation when compiling malicious input) の修正取り込み。frontend の dev 依存 (vite 経由) の transitive dep のため lockfile のみ更新
 
 ---
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260507-1"
+__version__ = "20260509-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260507-1"
+version = "20260509-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "nekonoverse"
-version = "20260507.post1"
+version = "20260509.post1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260507-1",
+  "version": "20260509-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260507-1",
+      "version": "20260509-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4068,9 +4068,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260507-1",
+  "version": "20260509-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release 20260509-1

### セキュリティ

- **fast-uri 3.1.0 → 3.1.2** — CVE-2026-6321 / GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments, HIGH) の修正取り込み。frontend の dev 依存 (vitest 経由 ajv) の transitive dep のため lockfile のみ更新 (#1029)
- **@babel/plugin-transform-modules-systemjs 7.29.0 → 7.29.4** — GHSA (HIGH, arbitrary code generation when compiling malicious input) の修正取り込み。frontend の dev 依存 (vite 経由) の transitive dep のため lockfile のみ更新 (#1030)

🤖 Generated with [Claude Code](https://claude.com/claude-code)