### PR TITLE
Release 20260513-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [20260513-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260513-1) — 2026-05-13
+
+### セキュリティ
+
+- **urllib3 2.6.3 → 2.7.0** — GHSA-qccp-gfcp-xxvc (プロキシ経由の低レベルリダイレクトでセンシティブヘッダがクロスオリジン転送される, HIGH) / GHSA-mf9v-mfxr-j63j (ストリーミング API の一部で解凍爆弾防御をバイパス可能, HIGH) の修正取り込み。botocore / requests 等の transitive dep のため uv.lock のみ更新 (#1032)
+
+---
+
 ## [20260509-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260509-1) — 2026-05-09
 
 ### セキュリティ

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260509-1"
+__version__ = "20260513-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260509-1"
+version = "20260513-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1768,11 +1768,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "nekonoverse"
-version = "20260509.post1"
+version = "20260513.post1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260509-1",
+  "version": "20260513-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260509-1",
+      "version": "20260513-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260509-1",
+  "version": "20260513-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## セキュリティ

- **urllib3 2.6.3 → 2.7.0** — GHSA-qccp-gfcp-xxvc (プロキシ経由の低レベルリダイレクトでセンシティブヘッダがクロスオリジン転送される, HIGH) / GHSA-mf9v-mfxr-j63j (ストリーミング API の一部で解凍爆弾防御をバイパス可能, HIGH) の修正取り込み。botocore / requests 等の transitive dep のため uv.lock のみ更新 (#1032)

🤖 Generated with [Claude Code](https://claude.com/claude-code)