### PR TITLE
Release 20260517-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [20260517-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260517-1) — 2026-05-17
+
+### セキュリティ
+
+- **TOTP コードのリプレイ防止** — RFC 6238 §5.2 に準拠し、検証成功した time-step counter を `users.last_totp_counter` に永続化、それ以下のカウンタの OTP を拒否する単調増加方式を導入。`valid_window=1` (前後 30 秒) で許容されていた同一/過去カウンタの再使用を塞ぐ。`/auth/totp/verify`、`/auth/totp/enable`、OAuth フロー内の TOTP 検証すべてに適用。並列同一コードに対しては atomic CAS UPDATE (`UPDATE ... WHERE last_totp_counter IS NULL OR last_totp_counter < :c`) で race condition を排除し、TOTP 成功直後に commit してロールバック耐性も確保。リカバリーコード認証成功時にも現在 time-step まで counter を進める defense-in-depth を追加 (#1035)
+
+---
+
 ## [20260513-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260513-1) — 2026-05-13
 
 ### セキュリティ

--- a/backend/alembic/versions/043_add_last_totp_counter.py
+++ b/backend/alembic/versions/043_add_last_totp_counter.py
@@ -1,0 +1,28 @@
+"""TOTP リプレイ防止のため最後に成功した time-step counter を users に保存する。
+
+RFC 6238 §5.2 に従い、同一カウンタ (および過去カウンタ) の OTP 再使用を拒否するため
+の単調増加カウンタ。
+
+Revision ID: 043
+Revises: 042
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "043"
+down_revision = "042"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("last_totp_counter", sa.BigInteger(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "last_totp_counter")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -896,10 +896,11 @@ async def totp_enable(
     db: AsyncSession = Depends(get_db),
 ):
     from app.services.totp_service import (
+        advance_last_totp_counter,
         decrypt_secret,
         generate_recovery_codes,
         hash_recovery_codes,
-        verify_totp_code,
+        verify_totp_code_with_counter,
     )
 
     if user.totp_enabled:
@@ -914,7 +915,17 @@ async def totp_enable(
         )
 
     secret = decrypt_secret(user.totp_secret)
-    if not verify_totp_code(secret, body.code):
+    matched_counter = verify_totp_code_with_counter(
+        secret, body.code, user.last_totp_counter,
+    )
+    if matched_counter is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid TOTP code",
+        )
+    advanced = await advance_last_totp_counter(db, user.id, matched_counter)
+    if not advanced:
+        # 並列リクエストが先に同じカウンタを記録 — リプレイとして拒否
         raise HTTPException(
             status_code=400,
             detail="Invalid TOTP code",
@@ -989,14 +1000,29 @@ async def totp_verify(
     if not user:
         raise HTTPException(status_code=401, detail="User not found")
 
-    from app.services.totp_service import decrypt_secret, verify_totp_code
+    from app.services.totp_service import (
+        advance_last_totp_counter,
+        current_time_step,
+        decrypt_secret,
+        verify_totp_code_with_counter,
+    )
 
     secret = decrypt_secret(user.totp_secret)
     code = body.code.strip().replace("-", "")
 
-    if verify_totp_code(secret, code):
-        # 有効な TOTP コード — セッションを作成
-        pass
+    matched_counter = verify_totp_code_with_counter(
+        secret, code, user.last_totp_counter,
+    )
+    if matched_counter is not None:
+        # 有効な TOTP コード — atomic CAS でカウンタを進める。
+        # 並列リクエストに先を越されたら (rowcount==0) リプレイとして拒否し、
+        # セッション発行前にコミットして耐ロールバック性も確保する。
+        advanced = await advance_last_totp_counter(db, user.id, matched_counter)
+        if not advanced:
+            await valkey.incr(attempts_key)
+            await valkey.expire(attempts_key, TOTP_LOCKOUT_TTL)
+            raise HTTPException(status_code=401, detail="Invalid TOTP code")
+        await db.commit()
     elif user.totp_recovery_codes:
         # リカバリーコードを試行
         from app.services.totp_service import verify_recovery_code
@@ -1015,6 +1041,9 @@ async def totp_verify(
                 detail="Invalid TOTP code",
             )
         user.totp_recovery_codes = remaining
+        # Defense-in-depth: リカバリー認証成功時も TOTP カウンタを現在ステップまで
+        # 進めておくと、リカバリー直後に古い TOTP を再生される穴を塞げる。
+        await advance_last_totp_counter(db, user.id, current_time_step())
         await db.commit()
     else:
         # 失敗時に試行カウンターをインクリメント

--- a/backend/app/api/oauth.py
+++ b/backend/app/api/oauth.py
@@ -369,11 +369,27 @@ async def authorize_submit(
         if not user:
             raise HTTPException(status_code=401, detail="User not found")
 
-        from app.services.totp_service import decrypt_secret, verify_totp_code
+        from app.services.totp_service import (
+            advance_last_totp_counter,
+            current_time_step,
+            decrypt_secret,
+            verify_totp_code_with_counter,
+        )
 
         secret = decrypt_secret(user.totp_secret)
         code = totp_code.strip().replace("-", "")
-        totp_valid = verify_totp_code(secret, code)
+        matched_counter = verify_totp_code_with_counter(
+            secret, code, user.last_totp_counter,
+        )
+        totp_valid = False
+        if matched_counter is not None:
+            # atomic CAS で並列同一コードのリプレイを拒否
+            advanced = await advance_last_totp_counter(
+                db, user.id, matched_counter,
+            )
+            if advanced:
+                await db.commit()
+                totp_valid = True
 
         if not totp_valid and user.totp_recovery_codes:
             from app.services.totp_service import verify_recovery_code
@@ -383,6 +399,8 @@ async def authorize_submit(
             )
             if valid:
                 user.totp_recovery_codes = remaining
+                # Defense-in-depth: リカバリー成功時も TOTP カウンタを進める
+                await advance_last_totp_counter(db, user.id, current_time_step())
                 await db.commit()
                 totp_valid = True
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -34,6 +34,9 @@ class User(Base):
         Boolean, default=False, server_default="false", nullable=False
     )
     totp_recovery_codes: Mapped[Optional[list]] = mapped_column(JSON, nullable=True, default=None)
+    last_totp_counter: Mapped[Optional[int]] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     email_verified: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false", nullable=False
     )

--- a/backend/app/services/totp_service.py
+++ b/backend/app/services/totp_service.py
@@ -2,12 +2,19 @@ import base64
 import hashlib
 import secrets
 import string
+import time
+import uuid
 
 import bcrypt as _bcrypt
 import pyotp
+import sqlalchemy as sa
 from cryptography.fernet import Fernet
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+
+TOTP_STEP_SECONDS = 30
+TOTP_VALID_WINDOW = 1
 
 
 def _get_fernet() -> Fernet:
@@ -56,8 +63,77 @@ def generate_provisioning_uri(
 
 
 def verify_totp_code(secret: str, code: str) -> bool:
+    """非推奨。リプレイ保護なし。新規利用は verify_totp_code_with_counter を使うこと。"""
     totp = pyotp.TOTP(secret)
-    return totp.verify(code, valid_window=1)
+    return totp.verify(code, valid_window=TOTP_VALID_WINDOW)
+
+
+def current_time_step(now: float | None = None) -> int:
+    """現在の TOTP time-step counter を返す (Unix time / 30)。"""
+    if now is None:
+        now = time.time()
+    return int(now) // TOTP_STEP_SECONDS
+
+
+async def advance_last_totp_counter(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    new_counter: int,
+) -> bool:
+    """atomic に users.last_totp_counter を進める (単調増加 CAS)。
+
+    rowcount == 1 (採用された) なら True、別リクエストが先に同等以上の
+    counter を記録していたら False を返す。リプレイ防止の競合解決に使う。
+    呼び出し側でコミットすること。
+    """
+    from app.models.user import User
+    result = await db.execute(
+        sa.update(User)
+        .where(User.id == user_id)
+        .where(
+            sa.or_(
+                User.last_totp_counter.is_(None),
+                User.last_totp_counter < new_counter,
+            )
+        )
+        .values(last_totp_counter=new_counter)
+    )
+    return result.rowcount > 0
+
+
+def verify_totp_code_with_counter(
+    secret: str,
+    code: str,
+    last_counter: int | None,
+    now: float | None = None,
+) -> int | None:
+    # RFC 6238 §5.2: 受理済みの time-step に対する OTP は再使用を拒否する。
+    # 成功時は採用された counter (>= last_counter+1) を返し、失敗時は None を返す。
+    # 注: pyotp.TOTP.at(int) は整数を Unix timestamp として解釈するため、
+    #     counter を直接渡せる HOTP.at(counter) を使う (HOTP/TOTP は同一アルゴリズム)。
+    if now is None:
+        now = time.time()
+    current = int(now) // TOTP_STEP_SECONDS
+    hotp = pyotp.HOTP(secret)
+    candidate = (code or "").strip().replace(" ", "")
+    if not candidate:
+        return None
+    # 隣接ウィンドウは現在を優先しつつ前後を許容する標準的な順序で比較する。
+    offsets = [0]
+    for i in range(1, TOTP_VALID_WINDOW + 1):
+        offsets.extend((-i, i))
+    matched: int | None = None
+    for offset in offsets:
+        counter = current + offset
+        expected = hotp.at(counter)
+        if secrets.compare_digest(expected, candidate):
+            matched = counter
+            break
+    if matched is None:
+        return None
+    if last_counter is not None and matched <= last_counter:
+        return None
+    return matched
 
 
 def generate_recovery_codes(count: int = 8) -> list[str]:

--- a/backend/tests/test_oauth_totp.py
+++ b/backend/tests/test_oauth_totp.py
@@ -87,7 +87,8 @@ async def test_oauth_login_totp_verify_success(
     with patch(
         "app.services.totp_service.decrypt_secret", return_value="plain_secret",
     ), patch(
-        "app.services.totp_service.verify_totp_code", return_value=True,
+        "app.services.totp_service.verify_totp_code_with_counter",
+        return_value=99999,
     ):
         resp = await app_client.post(
             "/oauth/authorize",
@@ -142,7 +143,8 @@ async def test_oauth_login_totp_verify_invalid(
     with patch(
         "app.services.totp_service.decrypt_secret", return_value="plain_secret",
     ), patch(
-        "app.services.totp_service.verify_totp_code", return_value=False,
+        "app.services.totp_service.verify_totp_code_with_counter",
+        return_value=None,
     ):
         resp = await app_client.post(
             "/oauth/authorize",
@@ -335,7 +337,8 @@ async def test_oauth_totp_oob(app_client, db, test_user, mock_valkey):
     with patch(
         "app.services.totp_service.decrypt_secret", return_value="plain_secret",
     ), patch(
-        "app.services.totp_service.verify_totp_code", return_value=True,
+        "app.services.totp_service.verify_totp_code_with_counter",
+        return_value=99999,
     ):
         resp = await app_client.post(
             "/oauth/authorize",

--- a/backend/tests/test_totp.py
+++ b/backend/tests/test_totp.py
@@ -48,6 +48,107 @@ def test_verify_totp_code_invalid():
     assert verify_totp_code("JBSWY3DPEHPK3PXP", "000000") is False
 
 
+def test_verify_totp_code_with_counter_returns_counter():
+    from app.services.totp_service import (
+        TOTP_STEP_SECONDS,
+        verify_totp_code_with_counter,
+    )
+
+    secret = "JBSWY3DPEHPK3PXP"
+    expected_counter = 56000000
+    now = expected_counter * TOTP_STEP_SECONDS
+    code = pyotp.HOTP(secret).at(expected_counter)
+    matched = verify_totp_code_with_counter(secret, code, None, now=now)
+    assert matched == expected_counter
+
+
+def test_verify_totp_code_with_counter_rejects_replay():
+    """RFC 6238 §5.2: 同一カウンタの OTP の再使用は拒否されること。"""
+    from app.services.totp_service import (
+        TOTP_STEP_SECONDS,
+        verify_totp_code_with_counter,
+    )
+
+    secret = "JBSWY3DPEHPK3PXP"
+    counter = 56000000
+    now = counter * TOTP_STEP_SECONDS
+    code = pyotp.HOTP(secret).at(counter)
+
+    first = verify_totp_code_with_counter(secret, code, None, now=now)
+    assert first == counter
+
+    # 同じカウンタを last_counter として渡すと、同じコードは拒否される
+    second = verify_totp_code_with_counter(secret, code, first, now=now)
+    assert second is None
+
+
+def test_verify_totp_code_with_counter_rejects_older_window():
+    """前ステップ (last_counter-1) のコードも単調増加性により拒否されること。"""
+    from app.services.totp_service import (
+        TOTP_STEP_SECONDS,
+        verify_totp_code_with_counter,
+    )
+
+    secret = "JBSWY3DPEHPK3PXP"
+    current = 56000000
+    now = current * TOTP_STEP_SECONDS
+    prev_code = pyotp.HOTP(secret).at(current - 1)
+
+    # last_counter として現在カウンタを既に使用したとマーク
+    matched = verify_totp_code_with_counter(secret, prev_code, current, now=now)
+    assert matched is None
+
+
+def test_verify_totp_code_with_counter_invalid_code():
+    from app.services.totp_service import verify_totp_code_with_counter
+
+    assert verify_totp_code_with_counter("JBSWY3DPEHPK3PXP", "000000", None) is None
+
+
+# ── advance_last_totp_counter (atomic CAS) tests ──
+
+
+async def test_advance_last_totp_counter_initial(db, test_user):
+    """NULL から初回 advance は成功する。"""
+    from app.services.totp_service import advance_last_totp_counter
+
+    assert test_user.last_totp_counter is None
+    ok = await advance_last_totp_counter(db, test_user.id, 100)
+    assert ok is True
+    await db.refresh(test_user)
+    assert test_user.last_totp_counter == 100
+
+
+async def test_advance_last_totp_counter_replay_rejected(db, test_user):
+    """同一カウンタを 2 回 advance すると 2 回目は False (race condition 防止)。"""
+    from app.services.totp_service import advance_last_totp_counter
+
+    ok1 = await advance_last_totp_counter(db, test_user.id, 200)
+    ok2 = await advance_last_totp_counter(db, test_user.id, 200)
+    assert ok1 is True
+    assert ok2 is False
+
+
+async def test_advance_last_totp_counter_downgrade_rejected(db, test_user):
+    """過去カウンタへのダウングレードは拒否される。"""
+    from app.services.totp_service import advance_last_totp_counter
+
+    assert await advance_last_totp_counter(db, test_user.id, 300) is True
+    assert await advance_last_totp_counter(db, test_user.id, 250) is False
+    await db.refresh(test_user)
+    assert test_user.last_totp_counter == 300
+
+
+async def test_advance_last_totp_counter_monotonic_increase(db, test_user):
+    """より大きいカウンタへの advance は成功する。"""
+    from app.services.totp_service import advance_last_totp_counter
+
+    assert await advance_last_totp_counter(db, test_user.id, 400) is True
+    assert await advance_last_totp_counter(db, test_user.id, 401) is True
+    await db.refresh(test_user)
+    assert test_user.last_totp_counter == 401
+
+
 def test_generate_recovery_codes():
     from app.services.totp_service import generate_recovery_codes
 
@@ -237,6 +338,45 @@ async def test_totp_verify_success(app_client, test_user, db, mock_valkey):
     assert resp.json()["ok"] is True
     # Attempt counter should be deleted on success
     mock_valkey.delete.assert_any_call(f"totp_attempts:{totp_token}")
+    # 検証成功時にユーザーの last_totp_counter が更新されているべき
+    await db.refresh(test_user)
+    assert test_user.last_totp_counter is not None
+
+
+async def test_totp_verify_rejects_replay(app_client, test_user, db, mock_valkey):
+    """同一カウンタの TOTP コードを 2 回送信したら 2 回目は拒否されること (RFC 6238 §5.2)。"""
+    from app.services.totp_service import encrypt_secret
+
+    secret = "JBSWY3DPEHPK3PXP"
+    test_user.totp_enabled = True
+    test_user.totp_secret = encrypt_secret(secret)
+    await db.commit()
+
+    totp_token = uuid.uuid4().hex
+    mock_valkey.get = AsyncMock(
+        side_effect=_totp_verify_get_side_effect(str(test_user.id)),
+    )
+
+    totp = pyotp.TOTP(secret)
+    code = totp.now()
+
+    # 1 回目: 成功
+    resp1 = await app_client.post(
+        "/api/v1/auth/totp/verify",
+        json={"totp_token": totp_token, "code": code},
+    )
+    assert resp1.status_code == 200
+
+    # 2 回目: 同じコード — 拒否されるべき
+    totp_token2 = uuid.uuid4().hex
+    mock_valkey.get = AsyncMock(
+        side_effect=_totp_verify_get_side_effect(str(test_user.id)),
+    )
+    resp2 = await app_client.post(
+        "/api/v1/auth/totp/verify",
+        json={"totp_token": totp_token2, "code": code},
+    )
+    assert resp2.status_code == 401
 
 
 async def test_totp_verify_invalid_code(app_client, test_user, db, mock_valkey):


### PR DESCRIPTION
## 20260517-1 — 2026-05-17

### セキュリティ

- **TOTP コードのリプレイ防止 (#1035)** — RFC 6238 §5.2 準拠。検証成功した time-step counter を `users.last_totp_counter` に永続化し、同一/過去カウンタの OTP 再使用を拒否。`/auth/totp/verify`、`/auth/totp/enable`、OAuth フローすべてに適用。並列同一コードは atomic CAS UPDATE で排除、TOTP 成功直後に commit してロールバック耐性も確保。リカバリーコード認証時にも counter を現在ステップまで進める defense-in-depth。

🤖 Generated with [Claude Code](https://claude.com/claude-code)