### PR TITLE
fix: バージョン番号 3 箇所を 20260517-2 に揃える

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [20260517-2](https://github.com/nekonoverse/nekonoverse/releases/tag/20260517-2) — 2026-05-17
+
+### バグ修正
+
+- **バージョン番号の更新漏れを修正** — 20260517-1 のリリース時に `backend/app/__init__.py`, `backend/pyproject.toml`, `frontend/package.json` のバージョン番号が `20260513-1` のまま据え置かれていた。`__version__` を参照する nodeinfo が古いバージョンを返し続け、クライアントのアップデート検知が反応しないため、3 箇所を `20260517-2` に揃えるパッチ。
+
+---
+
 ## [20260517-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260517-1) — 2026-05-17
 
 ### セキュリティ

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260513-1"
+__version__ = "20260517-2"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260513-1"
+version = "20260517-2"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "nekonoverse"
-version = "20260513.post1"
+version = "20260517.post2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260513-1",
+  "version": "20260517-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260513-1",
+      "version": "20260517-2",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260513-1",
+  "version": "20260517-2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- 3 ファイルのバージョン番号が `20260513-1` から更新されないまま `20260517-2` まで放置されていた問題を patch リリースで一気に同期する。
  - `backend/app/__init__.py` の `__version__`
  - `backend/pyproject.toml` の `version`
  - `frontend/package.json` の `version`
  - lockfile 2 種類 (`frontend/package-lock.json`, `backend/uv.lock`) も再生成して同期
- CHANGELOG.md に `20260517-2` エントリを追加。

## Background
バージョン番号は nodeinfo の `software.version` として返されるため、これが古いままだとクライアントの自動アップデート検知が反応しません。`20260513-1` 以降のリリース (`20260517-1`) で CHANGELOG だけ更新してこの 3 箇所を放置していたミスを修正します。

## Test plan
- [ ] CI 通過
- [ ] マージ後、リリース PR (`Release 20260517-2`) を新規作成してリリースを実施
- [ ] リリース後 `/.well-known/nodeinfo` の `software.version` が `20260517-2` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)