### PR TITLE
feat: ActivityPub HTTP Signature の Ed25519 対応 (#1040)

### DIFF
--- a/backend/alembic/versions/044_add_ed25519_keys.py
+++ b/backend/alembic/versions/044_add_ed25519_keys.py
@@ -67,13 +67,10 @@ def upgrade() -> None:
     )
 
     # delivery_worker._find_target_actor_for_inbox は OR (inbox_url, shared_inbox_url) で
-    # actors を引くため、両カラムに部分 index が無いと配送毎にシーケンシャルスキャンになる。
-    op.create_index(
-        "ix_actors_inbox_url",
-        "actors",
-        ["inbox_url"],
-        postgresql_where=sa.text("inbox_url IS NOT NULL"),
-    )
+    # actors を引くため、両カラムに index が無いと配送毎にシーケンシャルスキャンになる。
+    # inbox_url は NOT NULL のため通常 index、shared_inbox_url は nullable のため
+    # 部分 index で省サイズ化する。
+    op.create_index("ix_actors_inbox_url", "actors", ["inbox_url"])
     op.create_index(
         "ix_actors_shared_inbox_url",
         "actors",

--- a/backend/alembic/versions/044_add_ed25519_keys.py
+++ b/backend/alembic/versions/044_add_ed25519_keys.py
@@ -1,0 +1,100 @@
+"""FEP-521a Multikey 形式の Ed25519 鍵カラムを追加し、既存ローカル User に backfill する。
+
+issue #1040 (Fedibird/Mitra 等が Ed25519 をサポートしているため対応)。
+RSA 鍵は据え置きで、新カラムを追加するだけのため後方互換あり。
+
+Revision ID: 044
+Revises: 043
+"""
+
+import sqlalchemy as sa
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from alembic import op
+
+revision = "044"
+down_revision = "043"
+branch_labels = None
+depends_on = None
+
+# crypto.py と同一の定義 (migration を独立して動かせるよう手書きで複製)
+_ED25519_MULTICODEC_PREFIX = b"\xed\x01"
+_BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _base58btc_encode(data: bytes) -> str:
+    n = int.from_bytes(data, "big")
+    out = ""
+    while n > 0:
+        n, r = divmod(n, 58)
+        out = _BASE58_ALPHABET[r] + out
+    for byte in data:
+        if byte == 0:
+            out = _BASE58_ALPHABET[0] + out
+        else:
+            break
+    return out
+
+
+def _gen_ed25519() -> tuple[str, str]:
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    raw_public = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    multibase = "z" + _base58btc_encode(_ED25519_MULTICODEC_PREFIX + raw_public)
+    return pem, multibase
+
+
+def upgrade() -> None:
+    op.add_column(
+        "actors",
+        sa.Column("public_key_ed25519_multibase", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "actors",
+        sa.Column("key_id_ed25519", sa.String(2048), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("private_key_ed25519_pem", sa.Text(), nullable=True),
+    )
+
+    # 既存ローカル User (actors.domain IS NULL) 全員に Ed25519 鍵ペアを生成して backfill。
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text(
+            "SELECT u.id AS user_id, a.id AS actor_id, a.ap_id "
+            "FROM users u JOIN actors a ON u.actor_id = a.id "
+            "WHERE a.domain IS NULL"
+        )
+    ).fetchall()
+    for row in rows:
+        private_pem, multibase = _gen_ed25519()
+        conn.execute(
+            sa.text("UPDATE users SET private_key_ed25519_pem = :pem WHERE id = :uid"),
+            {"pem": private_pem, "uid": row.user_id},
+        )
+        conn.execute(
+            sa.text(
+                "UPDATE actors SET public_key_ed25519_multibase = :mb, "
+                "key_id_ed25519 = :kid WHERE id = :aid"
+            ),
+            {
+                "mb": multibase,
+                "kid": f"{row.ap_id}#ed25519-key",
+                "aid": row.actor_id,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "private_key_ed25519_pem")
+    op.drop_column("actors", "key_id_ed25519")
+    op.drop_column("actors", "public_key_ed25519_multibase")

--- a/backend/alembic/versions/044_add_ed25519_keys.py
+++ b/backend/alembic/versions/044_add_ed25519_keys.py
@@ -66,6 +66,21 @@ def upgrade() -> None:
         sa.Column("private_key_ed25519_pem", sa.Text(), nullable=True),
     )
 
+    # delivery_worker._find_target_actor_for_inbox は OR (inbox_url, shared_inbox_url) で
+    # actors を引くため、両カラムに部分 index が無いと配送毎にシーケンシャルスキャンになる。
+    op.create_index(
+        "ix_actors_inbox_url",
+        "actors",
+        ["inbox_url"],
+        postgresql_where=sa.text("inbox_url IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_actors_shared_inbox_url",
+        "actors",
+        ["shared_inbox_url"],
+        postgresql_where=sa.text("shared_inbox_url IS NOT NULL"),
+    )
+
     # 既存ローカル User (actors.domain IS NULL) 全員に Ed25519 鍵ペアを生成して backfill。
     conn = op.get_bind()
     rows = conn.execute(
@@ -95,6 +110,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    op.drop_index("ix_actors_shared_inbox_url", table_name="actors")
+    op.drop_index("ix_actors_inbox_url", table_name="actors")
     op.drop_column("users", "private_key_ed25519_pem")
     op.drop_column("actors", "key_id_ed25519")
     op.drop_column("actors", "public_key_ed25519_multibase")

--- a/backend/app/activitypub/http_signature.py
+++ b/backend/app/activitypub/http_signature.py
@@ -173,9 +173,12 @@ def verify_signature(
     declared = (params.get("algorithm") or "").lower()
     if declared == "ed25519":
         algo = "ed25519"
-    elif declared in ("rsa-sha256", ""):
+    elif declared == "rsa-sha256":
         algo = "rsa-sha256"
-    elif declared == "hs2019":
+    elif declared in ("hs2019", ""):
+        # algorithm 不在 / hs2019 はどちらも曖昧。algorithm_hint を尊重しつつ、
+        # なければ鍵種別から推定。Ed25519 鍵保有相手が空 algorithm を送ってきても
+        # 取りこぼさない。
         algo = algorithm_hint or ("ed25519" if is_multibase else "rsa-sha256")
     else:
         return False

--- a/backend/app/activitypub/http_signature.py
+++ b/backend/app/activitypub/http_signature.py
@@ -6,10 +6,13 @@ from email.utils import format_datetime, parsedate_to_datetime
 from urllib.parse import urlparse
 
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric import ed25519, padding, rsa
+
+from app.utils.crypto import ed25519_multibase_to_public_bytes
 
 
-# C-4: パース済みRSA鍵をキャッシュしてCPU負荷を削減
+# C-4: パース済み鍵をキャッシュして CPU 負荷を削減。
+# Ed25519 PEM も load_pem_*_key で型が判別されて返るため、関数自体は単一。
 @functools.lru_cache(maxsize=256)
 def _parse_private_key(pem: str):
     return serialization.load_pem_private_key(pem.encode(), password=None)
@@ -20,14 +23,27 @@ def _parse_public_key(pem: str):
     return serialization.load_pem_public_key(pem.encode())
 
 
+@functools.lru_cache(maxsize=1024)
+def _parse_public_key_multibase(multibase: str) -> ed25519.Ed25519PublicKey:
+    """FEP-521a Multikey (`z6Mk...`) を Ed25519PublicKey に復元する。"""
+    raw = ed25519_multibase_to_public_bytes(multibase)
+    return ed25519.Ed25519PublicKey.from_public_bytes(raw)
+
+
 def sign_request(
     private_key_pem: str,
     key_id: str,
     method: str,
     url: str,
     body: bytes | None = None,
+    algorithm: str = "rsa-sha256",
 ) -> dict[str, str]:
-    """ActivityPub 配送用に HTTP リクエストに署名する。"""
+    """ActivityPub 配送用に HTTP リクエストに署名する。
+
+    algorithm:
+      - "rsa-sha256" (デフォルト, cavage 互換): PKCS1v15 + SHA-256
+      - "ed25519": Ed25519 (内部で SHA-512、ハッシュ前計算不要)
+    """
     parsed = urlparse(url)
     path = parsed.path
     if parsed.query:
@@ -58,17 +74,27 @@ def sign_request(
     signed_string = "\n".join(signed_parts)
 
     private_key = _parse_private_key(private_key_pem)
-    signature = private_key.sign(
-        signed_string.encode("utf-8"),
-        padding.PKCS1v15(),
-        hashes.SHA256(),
-    )
+    if algorithm == "rsa-sha256":
+        if not isinstance(private_key, rsa.RSAPrivateKey):
+            raise TypeError("algorithm='rsa-sha256' requires an RSA private key")
+        signature = private_key.sign(
+            signed_string.encode("utf-8"),
+            padding.PKCS1v15(),
+            hashes.SHA256(),
+        )
+    elif algorithm == "ed25519":
+        if not isinstance(private_key, ed25519.Ed25519PrivateKey):
+            raise TypeError("algorithm='ed25519' requires an Ed25519 private key")
+        # Ed25519 はハッシュ前計算しない (内部で SHA-512)
+        signature = private_key.sign(signed_string.encode("utf-8"))
+    else:
+        raise ValueError(f"unsupported algorithm: {algorithm!r}")
 
     signature_b64 = base64.b64encode(signature).decode()
     headers_str = " ".join(headers_to_sign)
     sig_header = (
         f'keyId="{key_id}",'
-        f'algorithm="rsa-sha256",'
+        f'algorithm="{algorithm}",'
         f'headers="{headers_str}",'
         f'signature="{signature_b64}"'
     )
@@ -92,13 +118,24 @@ def parse_signature_header(sig_header: str) -> dict[str, str]:
 
 
 def verify_signature(
-    public_key_pem: str,
+    public_key_material: str,
     signature_header: str,
     method: str,
     path: str,
     headers: dict[str, str],
+    algorithm_hint: str | None = None,
 ) -> bool:
-    """公開鍵に対して HTTP Signature を検証する。"""
+    """公開鍵に対して HTTP Signature を検証する。
+
+    public_key_material:
+      - RSA PEM 文字列 ("-----BEGIN PUBLIC KEY-----" で始まる)、または
+      - Ed25519 Multikey (`z6Mk...`) のいずれか。
+
+    algorithm_hint:
+      - signature header の algorithm パラメータが `hs2019` や空の場合に、
+        どちらのアルゴリズムでパースするかを呼び出し側が指定する。
+        通常は鍵種別から自動判別する。
+    """
     params = parse_signature_header(signature_header)
 
     if "signature" not in params or "headers" not in params or "keyId" not in params:
@@ -126,14 +163,42 @@ def verify_signature(
 
     signed_string = "\n".join(signed_parts)
 
+    # 鍵種別の自動判別 (algorithm hint が無ければ public_key_material から推定)
+    is_multibase = public_key_material.startswith("z")
+
+    # algorithm パラメータの解釈:
+    #   - "ed25519" → Ed25519 強制
+    #   - "rsa-sha256" or 空 → RSA
+    #   - "hs2019" → algorithm_hint or 鍵種別から決定
+    declared = (params.get("algorithm") or "").lower()
+    if declared == "ed25519":
+        algo = "ed25519"
+    elif declared in ("rsa-sha256", ""):
+        algo = "rsa-sha256"
+    elif declared == "hs2019":
+        algo = algorithm_hint or ("ed25519" if is_multibase else "rsa-sha256")
+    else:
+        return False
+
+    # 鍵種別と algorithm の整合性を確認 (取り違えで誤受理しないよう厳格に)
+    if algo == "ed25519" and not is_multibase:
+        return False
+    if algo == "rsa-sha256" and is_multibase:
+        return False
+
     try:
-        public_key = _parse_public_key(public_key_pem)
-        public_key.verify(
-            base64.b64decode(params["signature"]),
-            signed_string.encode("utf-8"),
-            padding.PKCS1v15(),
-            hashes.SHA256(),
-        )
+        signature_bytes = base64.b64decode(params["signature"])
+        if algo == "rsa-sha256":
+            public_key = _parse_public_key(public_key_material)
+            public_key.verify(
+                signature_bytes,
+                signed_string.encode("utf-8"),
+                padding.PKCS1v15(),
+                hashes.SHA256(),
+            )
+        else:
+            ed_key = _parse_public_key_multibase(public_key_material)
+            ed_key.verify(signature_bytes, signed_string.encode("utf-8"))
         return True
     except Exception:
         return False

--- a/backend/app/activitypub/renderer.py
+++ b/backend/app/activitypub/renderer.py
@@ -17,6 +17,7 @@ def _iso_z(dt: datetime) -> str:
 AP_CONTEXT = [
     "https://www.w3.org/ns/activitystreams",
     "https://w3id.org/security/v1",
+    "https://w3id.org/security/multikey/v1",
     {
         "misskey": "https://misskey-hub.net/ns#",
         "toot": "http://joinmastodon.org/ns#",
@@ -81,6 +82,22 @@ def render_actor(actor: Actor) -> dict:
             "owner": actor_url,
             "publicKeyPem": actor.public_key_pem,
         },
+        # FEP-521a Multikey: Ed25519 鍵を assertionMethod 配列で公開 (Fedibird/Mitra 互換)。
+        # Mastodon 等は publicKey フィールドを使うので、後方互換のため双方を出力する。
+        **(
+            {
+                "assertionMethod": [
+                    {
+                        "id": f"{actor_url}#ed25519-key",
+                        "type": "Multikey",
+                        "controller": actor_url,
+                        "publicKeyMultibase": actor.public_key_ed25519_multibase,
+                    }
+                ]
+            }
+            if getattr(actor, "public_key_ed25519_multibase", None)
+            else {}
+        ),
         "endpoints": {
             "sharedInbox": shared_inbox or f"{settings.server_url}/inbox",
         },

--- a/backend/app/activitypub/routes.py
+++ b/backend/app/activitypub/routes.py
@@ -302,8 +302,8 @@ async def verify_inbox_signature(request: Request, db: AsyncSession) -> tuple[bo
     if not key_id:
         return False, ""
 
-    actor, public_key_pem = await get_actor_public_key(db, key_id)
-    if not public_key_pem:
+    actor, public_key_material, algorithm = await get_actor_public_key(db, key_id)
+    if not public_key_material:
         return False, key_id
 
     headers_dict = {k.lower(): v for k, v in request.headers.items()}
@@ -312,11 +312,12 @@ async def verify_inbox_signature(request: Request, db: AsyncSession) -> tuple[bo
         path += f"?{request.url.query}"
 
     valid = verify_signature(
-        public_key_pem=public_key_pem,
+        public_key_material=public_key_material,
         signature_header=sig_header,
         method=request.method,
         path=path,
         headers=headers_dict,
+        algorithm_hint=algorithm,
     )
     return valid, key_id
 

--- a/backend/app/models/actor.py
+++ b/backend/app/models/actor.py
@@ -110,13 +110,10 @@ class Actor(Base):
         Index("ix_actors_domain_username", "domain", "username"),
         Index("ix_actors_lower_username_domain", func.lower(username), "domain", unique=True),
         # delivery_worker._find_target_actor_for_inbox の OR (inbox_url, shared_inbox_url)
-        # 用。migration 044 で同名の部分 index を作成しており、テスト DB の
-        # Base.metadata.create_all でも整合させる。
-        Index(
-            "ix_actors_inbox_url",
-            "inbox_url",
-            postgresql_where=text("inbox_url IS NOT NULL"),
-        ),
+        # 用。migration 044 で同名の index を作成しており、テスト DB の
+        # Base.metadata.create_all でも整合させる。inbox_url は NOT NULL のため
+        # 通常 index、shared_inbox_url は nullable のため部分 index で省サイズ。
+        Index("ix_actors_inbox_url", "inbox_url"),
         Index(
             "ix_actors_shared_inbox_url",
             "shared_inbox_url",

--- a/backend/app/models/actor.py
+++ b/backend/app/models/actor.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -108,6 +109,19 @@ class Actor(Base):
         UniqueConstraint("username", "domain", name="uq_actors_username_domain"),
         Index("ix_actors_domain_username", "domain", "username"),
         Index("ix_actors_lower_username_domain", func.lower(username), "domain", unique=True),
+        # delivery_worker._find_target_actor_for_inbox の OR (inbox_url, shared_inbox_url)
+        # 用。migration 044 で同名の部分 index を作成しており、テスト DB の
+        # Base.metadata.create_all でも整合させる。
+        Index(
+            "ix_actors_inbox_url",
+            "inbox_url",
+            postgresql_where=text("inbox_url IS NOT NULL"),
+        ),
+        Index(
+            "ix_actors_shared_inbox_url",
+            "shared_inbox_url",
+            postgresql_where=text("shared_inbox_url IS NOT NULL"),
+        ),
     )
 
     @property

--- a/backend/app/models/actor.py
+++ b/backend/app/models/actor.py
@@ -38,6 +38,14 @@ class Actor(Base):
     followers_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     following_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     public_key_pem: Mapped[str] = mapped_column(Text, nullable=False)
+    # FEP-521a Multikey: Ed25519 公開鍵を `z6Mk...` の Multibase 文字列で保持。
+    # ローカルは migration 044 で生成、リモートは actor JSON-LD の assertionMethod 経由で保存。
+    public_key_ed25519_multibase: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, default=None
+    )
+    # リモートアクターから取り込んだ Ed25519 鍵の Multikey id (assertionMethod[].id)。
+    # ローカルでは `{actor_url}#ed25519-key` を都度生成するため参考値。
+    key_id_ed25519: Mapped[str | None] = mapped_column(String(2048), nullable=True, default=None)
     is_cat: Mapped[bool] = mapped_column(Boolean, default=False)
     manually_approves_followers: Mapped[bool] = mapped_column(Boolean, default=False)
     discoverable: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -29,6 +29,9 @@ class User(Base):
         Boolean, default=False, server_default="false", nullable=False
     )
     private_key_pem: Mapped[str] = mapped_column(Text, nullable=False)
+    # Ed25519 秘密鍵 (PKCS8 PEM)。migration 044 で既存ユーザーに backfill。
+    # 新規ユーザーは create_user 時に RSA とセットで生成される。
+    private_key_ed25519_pem: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
     totp_secret: Mapped[Optional[str]] = mapped_column(Text, nullable=True, default=None)
     totp_enabled: Mapped[bool] = mapped_column(
         Boolean, default=False, server_default="false", nullable=False

--- a/backend/app/services/actor_service.py
+++ b/backend/app/services/actor_service.py
@@ -234,6 +234,28 @@ async def upsert_remote_actor(db: AsyncSession, data: dict) -> Actor | None:
     if isinstance(pk, dict):
         public_key_pem = pk.get("publicKeyPem", "")
 
+    # FEP-521a Multikey: assertionMethod / verificationMethod から Ed25519 鍵を抽出。
+    # Ed25519 multibase は base58btc + multicodec varint 0xED 0x01 で必ず "z6Mk" で始まる。
+    ed25519_multibase: str | None = None
+    ed25519_key_id: str | None = None
+    for field in ("assertionMethod", "verificationMethod"):
+        method_value = data.get(field)
+        if not method_value:
+            continue
+        candidates = method_value if isinstance(method_value, list) else [method_value]
+        for cand in candidates:
+            if not isinstance(cand, dict):
+                continue
+            if cand.get("type") != "Multikey":
+                continue
+            mb = cand.get("publicKeyMultibase")
+            if isinstance(mb, str) and mb.startswith("z6Mk"):
+                ed25519_multibase = mb
+                ed25519_key_id = cand.get("id")
+                break
+        if ed25519_multibase:
+            break
+
     shared_inbox = None
     endpoints = data.get("endpoints")
     if isinstance(endpoints, dict):
@@ -317,6 +339,10 @@ async def upsert_remote_actor(db: AsyncSession, data: dict) -> Actor | None:
         existing.followers_url = data.get("followers")
         existing.following_url = data.get("following")
         existing.public_key_pem = public_key_pem or existing.public_key_pem
+        # Ed25519 鍵は新しい値が来た時だけ上書き (Mastodon 等から取得すると null になる)
+        if ed25519_multibase:
+            existing.public_key_ed25519_multibase = ed25519_multibase
+            existing.key_id_ed25519 = ed25519_key_id
         existing.last_fetched_at = now
         icon = data.get("icon")
         if isinstance(icon, dict):
@@ -373,6 +399,8 @@ async def upsert_remote_actor(db: AsyncSession, data: dict) -> Actor | None:
         followers_url=data.get("followers"),
         following_url=data.get("following"),
         public_key_pem=public_key_pem,
+        public_key_ed25519_multibase=ed25519_multibase,
+        key_id_ed25519=ed25519_key_id,
         is_cat=data.get("isCat", False),
         is_bot=is_bot,
         require_signin_to_view=bool(data.get("_misskey_requireSigninToViewContents", False)),
@@ -463,10 +491,25 @@ async def resolve_webfinger(db: AsyncSession, username: str, domain: str) -> Act
     return await fetch_remote_actor(db, ap_id)
 
 
-async def get_actor_public_key(db: AsyncSession, key_id: str) -> tuple[Actor | None, str]:
-    """鍵 ID (例: https://example.com/users/alice#main-key) からアクターと公開鍵を取得する。"""
+async def get_actor_public_key(
+    db: AsyncSession, key_id: str
+) -> tuple[Actor | None, str, str]:
+    """鍵 ID から (actor, public_key_material, algorithm) を返す。
+
+    key_id の fragment が actor の `key_id_ed25519` または `#ed25519-key` パターンに
+    一致し、かつ Ed25519 multibase が保存されていれば Ed25519 鍵を、それ以外は
+    RSA PEM を返す。algorithm は "ed25519" または "rsa-sha256"。
+    """
     actor_ap_id = key_id.split("#")[0]
     actor = await fetch_remote_actor(db, actor_ap_id)
-    if actor:
-        return actor, actor.public_key_pem
-    return None, ""
+    if not actor:
+        return None, "", "rsa-sha256"
+
+    # Ed25519 鍵判定: 保存済み key_id_ed25519 と完全一致するか、fragment が
+    # `ed25519-key` 系で multibase がセットされている場合。
+    if actor.public_key_ed25519_multibase:
+        fragment = key_id.split("#", 1)[1] if "#" in key_id else ""
+        if actor.key_id_ed25519 == key_id or "ed25519" in fragment.lower():
+            return actor, actor.public_key_ed25519_multibase, "ed25519"
+
+    return actor, actor.public_key_pem, "rsa-sha256"

--- a/backend/app/services/actor_service.py
+++ b/backend/app/services/actor_service.py
@@ -339,9 +339,12 @@ async def upsert_remote_actor(db: AsyncSession, data: dict) -> Actor | None:
         existing.followers_url = data.get("followers")
         existing.following_url = data.get("following")
         existing.public_key_pem = public_key_pem or existing.public_key_pem
-        # Ed25519 鍵: 相手が提示しなくなった (鍵廃止) ケースも反映するため、
-        # multibase が未抽出なら NULL に戻す。古い multibase で Ed25519 送信を
-        # 続けてしまうと検証側で必ず失敗するため、明示的に取り下げる方が安全。
+        # Ed25519 鍵: 相手が Multikey を提示しなくなった (鍵廃止) ケースを反映する
+        # ため、multibase が未抽出なら NULL に戻す。古い multibase で Ed25519 送信
+        # を続けると検証側で必ず失敗するので、明示的に取り下げる方が安全。
+        # 注: 一時的に Multikey を含まない actor JSON を返された場合 (CDN/キャッシュ
+        # 不整合等) 次回 fetch で復帰するまで RSA フォールバックになる窓ができるが、
+        # 致命ではない。両カラムは常に一緒に更新する不変条件。
         existing.public_key_ed25519_multibase = ed25519_multibase
         existing.key_id_ed25519 = ed25519_key_id
         existing.last_fetched_at = now
@@ -497,9 +500,11 @@ async def get_actor_public_key(
 ) -> tuple[Actor | None, str, str]:
     """鍵 ID から (actor, public_key_material, algorithm) を返す。
 
-    key_id の fragment が actor の `key_id_ed25519` または `#ed25519-key` パターンに
-    一致し、かつ Ed25519 multibase が保存されていれば Ed25519 鍵を、それ以外は
-    RSA PEM を返す。algorithm は "ed25519" または "rsa-sha256"。
+    `key_id` が actor の `key_id_ed25519` と完全一致した場合のみ Ed25519 鍵を
+    返す。それ以外は RSA PEM を返す。algorithm は "ed25519" または
+    "rsa-sha256"。fragment の部分一致 ("#main-key-ed25519-2024" 等) で誤判定
+    しないよう、リモートが actor JSON-LD の assertionMethod[].id で提示した
+    完全な URL に対してのみ Ed25519 と判定する。
     """
     actor_ap_id = key_id.split("#")[0]
     actor = await fetch_remote_actor(db, actor_ap_id)

--- a/backend/app/services/actor_service.py
+++ b/backend/app/services/actor_service.py
@@ -339,10 +339,11 @@ async def upsert_remote_actor(db: AsyncSession, data: dict) -> Actor | None:
         existing.followers_url = data.get("followers")
         existing.following_url = data.get("following")
         existing.public_key_pem = public_key_pem or existing.public_key_pem
-        # Ed25519 鍵は新しい値が来た時だけ上書き (Mastodon 等から取得すると null になる)
-        if ed25519_multibase:
-            existing.public_key_ed25519_multibase = ed25519_multibase
-            existing.key_id_ed25519 = ed25519_key_id
+        # Ed25519 鍵: 相手が提示しなくなった (鍵廃止) ケースも反映するため、
+        # multibase が未抽出なら NULL に戻す。古い multibase で Ed25519 送信を
+        # 続けてしまうと検証側で必ず失敗するため、明示的に取り下げる方が安全。
+        existing.public_key_ed25519_multibase = ed25519_multibase
+        existing.key_id_ed25519 = ed25519_key_id
         existing.last_fetched_at = now
         icon = data.get("icon")
         if isinstance(icon, dict):
@@ -505,11 +506,10 @@ async def get_actor_public_key(
     if not actor:
         return None, "", "rsa-sha256"
 
-    # Ed25519 鍵判定: 保存済み key_id_ed25519 と完全一致するか、fragment が
-    # `ed25519-key` 系で multibase がセットされている場合。
-    if actor.public_key_ed25519_multibase:
-        fragment = key_id.split("#", 1)[1] if "#" in key_id else ""
-        if actor.key_id_ed25519 == key_id or "ed25519" in fragment.lower():
-            return actor, actor.public_key_ed25519_multibase, "ed25519"
+    # Ed25519 鍵判定: 保存済み key_id_ed25519 と完全一致した場合のみ Ed25519 を返す。
+    # `#main-key-ed25519-2024` のような変則命名で誤判定するのを避けるため、
+    # リモートが actor JSON-LD で提示している assertionMethod[].id を信頼する。
+    if actor.public_key_ed25519_multibase and actor.key_id_ed25519 == key_id:
+        return actor, actor.public_key_ed25519_multibase, "ed25519"
 
     return actor, actor.public_key_pem, "rsa-sha256"

--- a/backend/app/services/system_account_service.py
+++ b/backend/app/services/system_account_service.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.models.actor import Actor
 from app.models.user import User
-from app.utils.crypto import generate_rsa_keypair
+from app.utils.crypto import generate_ed25519_keypair, generate_rsa_keypair
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +38,18 @@ async def ensure_system_account(
     )
     actor = result.scalar_one_or_none()
     if actor and actor.local_user:
+        # 既存システムアカウントで Ed25519 鍵未保有なら補完 (冪等)
+        if actor.public_key_ed25519_multibase is None:
+            ed_priv, ed_mb = generate_ed25519_keypair()
+            actor.public_key_ed25519_multibase = ed_mb
+            actor.key_id_ed25519 = f"{actor.ap_id}#ed25519-key"
+            actor.local_user.private_key_ed25519_pem = ed_priv
+            await db.commit()
+            await db.refresh(actor.local_user)
         return actor.local_user
 
     private_pem, public_pem = generate_rsa_keypair()
+    private_ed25519_pem, public_ed25519_multibase = generate_ed25519_keypair()
 
     actor_id = uuid.uuid4()
     ap_id = f"{settings.server_url}/users/{username}"
@@ -57,6 +66,8 @@ async def ensure_system_account(
         followers_url=f"{ap_id}/followers",
         following_url=f"{ap_id}/following",
         public_key_pem=public_pem,
+        public_key_ed25519_multibase=public_ed25519_multibase,
+        key_id_ed25519=f"{ap_id}#ed25519-key",
         is_bot=True,
         discoverable=False,
     )
@@ -76,6 +87,7 @@ async def ensure_system_account(
         role="admin",
         is_system=True,
         private_key_pem=private_pem,
+        private_key_ed25519_pem=private_ed25519_pem,
     )
     db.add(user)
     await db.commit()

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.models.actor import Actor
 from app.models.user import User
-from app.utils.crypto import generate_rsa_keypair
+from app.utils.crypto import generate_ed25519_keypair, generate_rsa_keypair
 
 # ユーザー登録で使用できない予約語（すべて小文字で比較）
 RESERVED_USERNAMES: frozenset[str] = frozenset({
@@ -58,8 +58,10 @@ async def create_user(
     if existing_email.scalar_one_or_none():
         raise ValueError("Username or email is already in use")
 
-    # RSA鍵ペアを生成
+    # RSA鍵ペアを生成 (Mastodon 等との後方互換のため継続使用)
     private_pem, public_pem = generate_rsa_keypair()
+    # Ed25519 鍵ペアを生成 (FEP-521a Multikey, Fedibird/Mitra 等向け)
+    private_ed25519_pem, public_ed25519_multibase = generate_ed25519_keypair()
 
     # アクターを作成
     actor_id = uuid.uuid4()
@@ -77,6 +79,8 @@ async def create_user(
         followers_url=f"{ap_id}/followers",
         following_url=f"{ap_id}/following",
         public_key_pem=public_pem,
+        public_key_ed25519_multibase=public_ed25519_multibase,
+        key_id_ed25519=f"{ap_id}#ed25519-key",
     )
     db.add(actor)
 
@@ -89,6 +93,7 @@ async def create_user(
         actor_id=actor_id,
         role=role,
         private_key_pem=private_pem,
+        private_key_ed25519_pem=private_ed25519_pem,
         approval_status=approval_status,
         registration_reason=registration_reason,
     )

--- a/backend/app/utils/crypto.py
+++ b/backend/app/utils/crypto.py
@@ -1,5 +1,11 @@
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
+
+# FEP-521a Multikey の Ed25519 multicodec プレフィックス (varint: 0xED 0x01)
+_ED25519_MULTICODEC_PREFIX = b"\xed\x01"
+
+# Bitcoin base58 alphabet (FEP-521a の base58btc に対応)
+_BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
 
 def generate_rsa_keypair() -> tuple[str, str]:
@@ -25,3 +31,77 @@ def generate_rsa_keypair() -> tuple[str, str]:
     )
 
     return private_pem, public_pem
+
+
+def _base58btc_encode(data: bytes) -> str:
+    """base58btc エンコード (Bitcoin alphabet 固定)。leading zero は '1' で表現。"""
+    n = int.from_bytes(data, "big")
+    out = ""
+    while n > 0:
+        n, r = divmod(n, 58)
+        out = _BASE58_ALPHABET[r] + out
+    for byte in data:
+        if byte == 0:
+            out = _BASE58_ALPHABET[0] + out
+        else:
+            break
+    return out
+
+
+def _base58btc_decode(text: str) -> bytes:
+    """base58btc デコード。不正な文字は ValueError。"""
+    n = 0
+    for ch in text:
+        idx = _BASE58_ALPHABET.find(ch)
+        if idx < 0:
+            raise ValueError(f"invalid base58btc character: {ch!r}")
+        n = n * 58 + idx
+    # 数値部分を big-endian に
+    body = n.to_bytes((n.bit_length() + 7) // 8, "big") if n > 0 else b""
+    # leading '1' を 0x00 byte に戻す
+    leading_zeros = 0
+    for ch in text:
+        if ch == _BASE58_ALPHABET[0]:
+            leading_zeros += 1
+        else:
+            break
+    return b"\x00" * leading_zeros + body
+
+
+def generate_ed25519_keypair() -> tuple[str, str]:
+    """Ed25519 鍵ペアを生成し、(private_pem_pkcs8, public_multibase) を返す。
+
+    public_multibase は FEP-521a Multikey 仕様の `z` プレフィックス + base58btc
+    エンコード形式 (例: `z6Mk...`)。multicodec varint `0xED 0x01` を含む。
+    """
+    private_key = ed25519.Ed25519PrivateKey.generate()
+
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+    raw_public = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    public_multibase = "z" + _base58btc_encode(_ED25519_MULTICODEC_PREFIX + raw_public)
+
+    return private_pem, public_multibase
+
+
+def ed25519_multibase_to_public_bytes(multibase: str) -> bytes:
+    """Multikey 形式 (`z6Mk...`) から Ed25519 公開鍵 32 byte を抽出する。
+
+    `z` 以外のプレフィックスや multicodec 不一致は ValueError。
+    """
+    if not multibase.startswith("z"):
+        raise ValueError("Multikey must start with 'z' (base58btc)")
+    decoded = _base58btc_decode(multibase[1:])
+    if not decoded.startswith(_ED25519_MULTICODEC_PREFIX):
+        raise ValueError("Multikey does not have Ed25519 multicodec prefix (0xED 0x01)")
+    raw = decoded[len(_ED25519_MULTICODEC_PREFIX) :]
+    if len(raw) != 32:
+        raise ValueError(f"Ed25519 public key must be 32 bytes, got {len(raw)}")
+    return raw

--- a/backend/app/worker/delivery_worker.py
+++ b/backend/app/worker/delivery_worker.py
@@ -30,8 +30,8 @@ ORPHAN_RECLAIM_THRESHOLD = timedelta(minutes=10)
 # ループ中に孤児回収を走らせる間隔。
 ORPHAN_RECLAIM_INTERVAL = timedelta(minutes=1)
 
-# L-1: 署名鍵キャッシュ (actor_id -> (Actor, private_key_pem, cached_at))
-_signing_key_cache: dict[uuid.UUID, tuple[Actor, str, float]] = {}
+# L-1: 署名鍵キャッシュ (actor_id -> (Actor, rsa_pem, ed25519_pem|None, cached_at))
+_signing_key_cache: dict[uuid.UUID, tuple[Actor, str, str | None, float]] = {}
 _SIGNING_KEY_CACHE_TTL = 3600  # 1 hour
 
 # ワーカー用の共有HTTPクライアント
@@ -116,25 +116,48 @@ async def get_next_jobs(db: AsyncSession, limit: int = 20) -> list[DeliveryJob]:
     return list(result.scalars().all())
 
 
-async def get_actor_with_key(db: AsyncSession, actor_id: uuid.UUID) -> tuple[Actor | None, str]:
-    """署名用にアクターとその秘密鍵を取得する。インメモリキャッシュを使用。"""
+async def get_actor_with_key(
+    db: AsyncSession, actor_id: uuid.UUID
+) -> tuple[Actor | None, str, str | None]:
+    """署名用にアクターと秘密鍵を取得する。(actor, rsa_pem, ed25519_pem|None)。
+
+    インメモリキャッシュを使用。Ed25519 鍵未保有の (古い) アクターは None を返す。
+    """
     import time
 
     cached = _signing_key_cache.get(actor_id)
     if cached:
-        actor, pem, cached_at = cached
+        actor, rsa_pem, ed_pem, cached_at = cached
         if time.time() - cached_at < _SIGNING_KEY_CACHE_TTL:
-            return actor, pem
+            return actor, rsa_pem, ed_pem
 
     result = await db.execute(
         select(Actor).options(selectinload(Actor.local_user)).where(Actor.id == actor_id)
     )
     actor = result.scalar_one_or_none()
     if not actor or not actor.local_user:
-        return actor, ""
+        return actor, "", None
 
-    _signing_key_cache[actor_id] = (actor, actor.local_user.private_key_pem, time.time())
-    return actor, actor.local_user.private_key_pem
+    rsa_pem = actor.local_user.private_key_pem
+    ed_pem = actor.local_user.private_key_ed25519_pem
+    _signing_key_cache[actor_id] = (actor, rsa_pem, ed_pem, time.time())
+    return actor, rsa_pem, ed_pem
+
+
+async def _find_target_actor_for_inbox(db: AsyncSession, inbox_url: str) -> Actor | None:
+    """配送先 inbox URL から相手リモートアクターを 1 件取得する。
+
+    共有 inbox の場合は複数候補があり得るが、鍵選択の判定には任意の代表 1 件で
+    十分 (共有 inbox の受信側でルーティングするため送信側の鍵種は自由)。失敗時は None。
+    """
+    from sqlalchemy import or_
+
+    result = await db.execute(
+        select(Actor)
+        .where(or_(Actor.inbox_url == inbox_url, Actor.shared_inbox_url == inbox_url))
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
 
 
 # 配送失敗時にエラーメッセージへ残すレスポンスボディの最大長。
@@ -143,7 +166,11 @@ _ERROR_BODY_PREVIEW_MAX = 300
 
 
 async def deliver_activity(
-    job: DeliveryJob, actor: Actor, private_key_pem: str
+    job: DeliveryJob,
+    actor: Actor,
+    private_key_pem: str,
+    private_key_ed25519_pem: str | None = None,
+    db: AsyncSession | None = None,
 ) -> tuple[bool, int, str]:
     """activity をリモート Inbox に配送する。
 
@@ -168,16 +195,28 @@ async def deliver_activity(
     body = json.dumps(job.payload).encode("utf-8")
     # 正しいスキームを保証するためローカルアクターの動的 URL を使用
     if actor.domain is None:
-        key_id = f"{app_settings.server_url}/users/{actor.username}#main-key"
+        actor_url_base = f"{app_settings.server_url}/users/{actor.username}"
     else:
-        key_id = f"{actor.ap_id}#main-key"
+        actor_url_base = actor.ap_id
+
+    # 鍵選択: 自分も相手も Ed25519 capable なら Ed25519、それ以外は RSA フォールバック。
+    algorithm = "rsa-sha256"
+    signing_key_pem = private_key_pem
+    key_id = f"{actor_url_base}#main-key"
+    if private_key_ed25519_pem and db is not None:
+        remote = await _find_target_actor_for_inbox(db, job.target_inbox_url)
+        if remote and remote.public_key_ed25519_multibase:
+            algorithm = "ed25519"
+            signing_key_pem = private_key_ed25519_pem
+            key_id = f"{actor_url_base}#ed25519-key"
 
     headers = sign_request(
-        private_key_pem=private_key_pem,
+        private_key_pem=signing_key_pem,
         key_id=key_id,
         method="POST",
         url=job.target_inbox_url,
         body=body,
+        algorithm=algorithm,
     )
     headers["Content-Type"] = AP_CONTENT_TYPE
 
@@ -212,7 +251,9 @@ async def _deliver_one(job_id: uuid.UUID, sem: asyncio.Semaphore) -> None:
             if not job or job.status != "processing":
                 return
 
-            actor, private_key_pem = await get_actor_with_key(db, job.actor_id)
+            actor, private_key_pem, private_key_ed25519_pem = await get_actor_with_key(
+                db, job.actor_id
+            )
             if not actor or not private_key_pem:
                 job.status = "dead"
                 job.error_message = "Actor or private key not found"
@@ -221,7 +262,7 @@ async def _deliver_one(job_id: uuid.UUID, sem: asyncio.Semaphore) -> None:
 
             try:
                 success, status_code, error_detail = await deliver_activity(
-                    job, actor, private_key_pem
+                    job, actor, private_key_pem, private_key_ed25519_pem, db=db
                 )
             except Exception as e:
                 # deliver_activity は想定される例外を握り潰す設計だが、

--- a/backend/tests/test_actor_service_extended.py
+++ b/backend/tests/test_actor_service_extended.py
@@ -187,6 +187,42 @@ async def test_upsert_no_multikey_keeps_ed25519_null(db):
     assert actor.key_id_ed25519 is None
 
 
+async def test_upsert_resets_ed25519_when_multikey_removed(db):
+    """create 時に Multikey ありの actor が update 時に Multikey を提示しなくなったら
+    NULL に戻すこと (古い multibase で Ed25519 送信を続けて検証失敗するのを防ぐ)。"""
+    multibase = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+    initial = {
+        "id": "http://rotate.example/users/rotateuser",
+        "type": "Person",
+        "preferredUsername": "rotateuser",
+        "inbox": "http://rotate.example/users/rotateuser/inbox",
+        "publicKey": {"publicKeyPem": "RSA_PEM"},
+        "assertionMethod": [
+            {
+                "id": "http://rotate.example/users/rotateuser#ed25519-key",
+                "type": "Multikey",
+                "publicKeyMultibase": multibase,
+            }
+        ],
+    }
+    actor = await upsert_remote_actor(db, initial)
+    assert actor.public_key_ed25519_multibase == multibase
+
+    # Multikey を含まない更新 (相手が Ed25519 を廃止 / 一時的に Multikey 抜きの actor JSON を返した)
+    updated = {
+        "id": "http://rotate.example/users/rotateuser",
+        "type": "Person",
+        "preferredUsername": "rotateuser",
+        "inbox": "http://rotate.example/users/rotateuser/inbox",
+        "publicKey": {"publicKeyPem": "RSA_PEM_NEW"},
+    }
+    actor2 = await upsert_remote_actor(db, updated)
+    assert actor2.id == actor.id
+    assert actor2.public_key_ed25519_multibase is None
+    assert actor2.key_id_ed25519 is None
+    assert actor2.public_key_pem == "RSA_PEM_NEW"
+
+
 async def test_upsert_creates_service_actor_as_bot(db):
     data = {
         "id": "http://bot.example/users/botuser",

--- a/backend/tests/test_actor_service_extended.py
+++ b/backend/tests/test_actor_service_extended.py
@@ -128,6 +128,65 @@ async def test_upsert_creates_full_actor(db):
     assert actor.is_bot is False
 
 
+async def test_upsert_extracts_ed25519_multikey(db):
+    """assertionMethod に Multikey (Ed25519) があれば actor に保存されること。"""
+    multibase = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+    data = {
+        "id": "http://ed.example/users/eduser",
+        "type": "Person",
+        "preferredUsername": "eduser",
+        "inbox": "http://ed.example/users/eduser/inbox",
+        "publicKey": {"publicKeyPem": "RSA_PEM"},
+        "assertionMethod": [
+            {
+                "id": "http://ed.example/users/eduser#ed25519-key",
+                "type": "Multikey",
+                "controller": "http://ed.example/users/eduser",
+                "publicKeyMultibase": multibase,
+            }
+        ],
+    }
+    actor = await upsert_remote_actor(db, data)
+    assert actor is not None
+    assert actor.public_key_ed25519_multibase == multibase
+    assert actor.key_id_ed25519 == "http://ed.example/users/eduser#ed25519-key"
+    # RSA 鍵も並存
+    assert actor.public_key_pem == "RSA_PEM"
+
+
+async def test_upsert_extracts_ed25519_from_verification_method_fallback(db):
+    """verificationMethod (一部実装が使う旧フィールド名) からも抽出できること。"""
+    multibase = "z6MkrYZ5LH3JxqFEFy4kHcwdcWnHmwwSXfwgQVrZbtAzGSqj"
+    data = {
+        "id": "http://vm.example/users/vmuser",
+        "type": "Person",
+        "preferredUsername": "vmuser",
+        "inbox": "http://vm.example/users/vmuser/inbox",
+        "publicKey": {"publicKeyPem": "RSA_PEM"},
+        "verificationMethod": {
+            "id": "http://vm.example/users/vmuser#ed25519-key",
+            "type": "Multikey",
+            "publicKeyMultibase": multibase,
+        },
+    }
+    actor = await upsert_remote_actor(db, data)
+    assert actor.public_key_ed25519_multibase == multibase
+
+
+async def test_upsert_no_multikey_keeps_ed25519_null(db):
+    """Multikey が無い (Mastodon 互換) アクターは Ed25519 カラムが null のまま。"""
+    data = {
+        "id": "http://mast.example/users/mastuser",
+        "type": "Person",
+        "preferredUsername": "mastuser",
+        "inbox": "http://mast.example/users/mastuser/inbox",
+        "publicKey": {"publicKeyPem": "RSA_PEM"},
+    }
+    actor = await upsert_remote_actor(db, data)
+    assert actor.public_key_ed25519_multibase is None
+    assert actor.key_id_ed25519 is None
+
+
 async def test_upsert_creates_service_actor_as_bot(db):
     data = {
         "id": "http://bot.example/users/botuser",
@@ -461,10 +520,11 @@ async def test_get_actor_public_key_found(db):
     await db.flush()
 
     key_id = f"{actor.ap_id}#main-key"
-    found_actor, pub_key = await get_actor_public_key(db, key_id)
+    found_actor, pub_key, algorithm = await get_actor_public_key(db, key_id)
     assert found_actor is not None
     assert found_actor.id == actor.id
     assert pub_key != ""
+    assert algorithm == "rsa-sha256"
 
 
 async def test_get_actor_public_key_not_found(db):
@@ -473,9 +533,29 @@ async def test_get_actor_public_key_not_found(db):
         new_callable=AsyncMock,
         return_value=None,
     ):
-        found_actor, pub_key = await get_actor_public_key(
+        found_actor, pub_key, algorithm = await get_actor_public_key(
             db,
             "http://nonexistent.example/users/nobody#main-key",
         )
     assert found_actor is None
     assert pub_key == ""
+    assert algorithm == "rsa-sha256"
+
+
+async def test_get_actor_public_key_ed25519(db):
+    """Ed25519 multibase を保持した actor に対して `#ed25519-key` fragment で
+    Ed25519 鍵と algorithm='ed25519' が返ること。"""
+    from app.utils.crypto import generate_ed25519_keypair
+
+    actor = await make_remote_actor(db, username="edactor", domain="ed.example")
+    _, multibase = generate_ed25519_keypair()
+    actor.public_key_ed25519_multibase = multibase
+    actor.key_id_ed25519 = f"{actor.ap_id}#ed25519-key"
+    actor.last_fetched_at = datetime.now(timezone.utc)
+    await db.flush()
+
+    key_id = f"{actor.ap_id}#ed25519-key"
+    found_actor, material, algorithm = await get_actor_public_key(db, key_id)
+    assert found_actor is not None
+    assert material == multibase
+    assert algorithm == "ed25519"

--- a/backend/tests/test_delivery_worker.py
+++ b/backend/tests/test_delivery_worker.py
@@ -128,23 +128,28 @@ async def test_get_pending_jobs_respects_limit(db, test_user, mock_valkey):
 
 
 async def test_get_actor_with_key_local(db, test_user, mock_valkey):
-    found_actor, found_key = await get_actor_with_key(db, test_user.actor_id)
+    found_actor, found_key, ed_key = await get_actor_with_key(db, test_user.actor_id)
     assert found_actor is not None
     assert found_actor.id == test_user.actor_id
     assert "PRIVATE KEY" in found_key
+    # test_user fixture が Ed25519 鍵も持っていれば返り、無ければ None。
+    # 044 移行後の create_user 経由なら必ず含まれる想定。
+    assert ed_key is None or "PRIVATE KEY" in ed_key
 
 
 async def test_get_actor_with_key_remote_no_key(db, mock_valkey):
     remote = await make_remote_actor(db, username="nokey")
-    found_actor, found_key = await get_actor_with_key(db, remote.id)
+    found_actor, found_key, ed_key = await get_actor_with_key(db, remote.id)
     assert found_actor is not None
     assert found_key == ""
+    assert ed_key is None
 
 
 async def test_get_actor_with_key_nonexistent(db, mock_valkey):
-    found_actor, found_key = await get_actor_with_key(db, uuid.uuid4())
+    found_actor, found_key, ed_key = await get_actor_with_key(db, uuid.uuid4())
     assert found_actor is None
     assert found_key == ""
+    assert ed_key is None
 
 
 # ── deliver_activity ──

--- a/backend/tests/test_http_signature.py
+++ b/backend/tests/test_http_signature.py
@@ -176,6 +176,28 @@ def test_hs2019_algorithm_dispatches_by_key_type():
     ) is True
 
 
+def test_empty_algorithm_with_ed25519_key_accepted():
+    """algorithm パラメータが空の場合も algorithm_hint と鍵種別を尊重する。
+
+    Ed25519 鍵保有相手が algorithm を省略してきても受理される (PR description の
+    『受信: algorithm が空 を受理』を Ed25519 鍵保有相手でも成立させる)。
+    """
+    ed_priv, ed_pub_mb = generate_ed25519_keypair()
+    headers = sign_request(
+        ed_priv, "key-id", "POST", "https://remote.example/inbox", algorithm="ed25519"
+    )
+    # algorithm パラメータを除去 (空状態をシミュレート)
+    import re
+
+    stripped = re.sub(r',?algorithm="[^"]*"', "", headers["Signature"])
+    verify_headers = {k.lower(): v for k, v in headers.items()}
+    verify_headers["signature"] = stripped
+    assert verify_signature(
+        ed_pub_mb, stripped, "POST", "/inbox", verify_headers,
+        algorithm_hint="ed25519",
+    ) is True
+
+
 def test_sign_rsa_algorithm_with_ed25519_key_raises():
     """algorithm='rsa-sha256' に Ed25519 秘密鍵を渡したら TypeError。"""
     import pytest

--- a/backend/tests/test_http_signature.py
+++ b/backend/tests/test_http_signature.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import datetime, timezone
 from email.utils import format_datetime
 
@@ -187,8 +188,6 @@ def test_empty_algorithm_with_ed25519_key_accepted():
         ed_priv, "key-id", "POST", "https://remote.example/inbox", algorithm="ed25519"
     )
     # algorithm パラメータを除去 (空状態をシミュレート)
-    import re
-
     stripped = re.sub(r',?algorithm="[^"]*"', "", headers["Signature"])
     verify_headers = {k.lower(): v for k, v in headers.items()}
     verify_headers["signature"] = stripped

--- a/backend/tests/test_http_signature.py
+++ b/backend/tests/test_http_signature.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from email.utils import format_datetime
 
 from app.activitypub.http_signature import parse_signature_header, sign_request, verify_signature
-from app.utils.crypto import generate_rsa_keypair
+from app.utils.crypto import generate_ed25519_keypair, generate_rsa_keypair
 
 
 def test_sign_returns_required_headers():
@@ -29,7 +29,10 @@ def test_sign_without_body_no_digest():
 
 
 def test_parse_signature_header():
-    sig = 'keyId="https://example.com/k",algorithm="rsa-sha256",headers="(request-target) host date",signature="abc123"'
+    sig = (
+        'keyId="https://example.com/k",algorithm="rsa-sha256",'
+        'headers="(request-target) host date",signature="abc123"'
+    )
     parsed = parse_signature_header(sig)
     assert parsed["keyId"] == "https://example.com/k"
     assert parsed["algorithm"] == "rsa-sha256"
@@ -39,9 +42,17 @@ def test_parse_signature_header():
 def test_sign_and_verify_roundtrip():
     priv, pub = generate_rsa_keypair()
     body = b'{"type":"Follow"}'
-    headers = sign_request(priv, "https://local.example/users/alice#main-key", "POST", "https://remote.example/inbox", body=body)
+    headers = sign_request(
+        priv,
+        "https://local.example/users/alice#main-key",
+        "POST",
+        "https://remote.example/inbox",
+        body=body,
+    )
     verify_headers = {k.lower(): v for k, v in headers.items()}
-    assert verify_signature(pub, headers["Signature"], "POST", "/inbox", verify_headers) is True
+    assert verify_signature(
+        pub, headers["Signature"], "POST", "/inbox", verify_headers
+    ) is True
 
 
 def test_verify_fails_with_wrong_key():
@@ -49,7 +60,9 @@ def test_verify_fails_with_wrong_key():
     _, wrong_pub = generate_rsa_keypair()
     headers = sign_request(priv, "key-id", "POST", "https://remote.example/inbox")
     verify_headers = {k.lower(): v for k, v in headers.items()}
-    assert verify_signature(wrong_pub, headers["Signature"], "POST", "/inbox", verify_headers) is False
+    assert verify_signature(
+        wrong_pub, headers["Signature"], "POST", "/inbox", verify_headers
+    ) is False
 
 
 def test_verify_fails_with_stale_date():
@@ -75,4 +88,119 @@ def test_sign_and_verify_with_query_string():
     priv, pub = generate_rsa_keypair()
     headers = sign_request(priv, "key-id", "GET", "https://remote.example/outbox?page=true")
     verify_headers = {k.lower(): v for k, v in headers.items()}
-    assert verify_signature(pub, headers["Signature"], "GET", "/outbox?page=true", verify_headers) is True
+    assert verify_signature(
+        pub, headers["Signature"], "GET", "/outbox?page=true", verify_headers
+    ) is True
+
+
+# ── Ed25519 (FEP-521a Multikey) ────────────────────────────────────────────
+
+
+def test_ed25519_sign_returns_required_headers():
+    priv, _ = generate_ed25519_keypair()
+    headers = sign_request(
+        priv, "key-id", "POST", "https://remote.example/inbox", algorithm="ed25519"
+    )
+    assert "Host" in headers
+    assert "Date" in headers
+    assert "Signature" in headers
+    # algorithm パラメータが 'ed25519' で出力されること
+    assert 'algorithm="ed25519"' in headers["Signature"]
+
+
+def test_ed25519_sign_and_verify_roundtrip():
+    priv, pub_mb = generate_ed25519_keypair()
+    body = b'{"type":"Follow"}'
+    headers = sign_request(
+        priv,
+        "https://local.example/users/alice#ed25519-key",
+        "POST",
+        "https://remote.example/inbox",
+        body=body,
+        algorithm="ed25519",
+    )
+    verify_headers = {k.lower(): v for k, v in headers.items()}
+    assert verify_signature(
+        pub_mb, headers["Signature"], "POST", "/inbox", verify_headers
+    ) is True
+
+
+def test_ed25519_verify_fails_with_wrong_key():
+    priv, _ = generate_ed25519_keypair()
+    _, wrong_pub_mb = generate_ed25519_keypair()
+    headers = sign_request(
+        priv, "key-id", "POST", "https://remote.example/inbox", algorithm="ed25519"
+    )
+    verify_headers = {k.lower(): v for k, v in headers.items()}
+    assert verify_signature(
+        wrong_pub_mb, headers["Signature"], "POST", "/inbox", verify_headers
+    ) is False
+
+
+def test_cross_verify_rsa_sig_with_ed25519_key_rejected():
+    """RSA で署名したものを Ed25519 公開鍵で検証 → algorithm 不整合で False。"""
+    rsa_priv, _ = generate_rsa_keypair()
+    _, ed_pub_mb = generate_ed25519_keypair()
+    headers = sign_request(rsa_priv, "key-id", "POST", "https://remote.example/inbox")
+    verify_headers = {k.lower(): v for k, v in headers.items()}
+    assert verify_signature(
+        ed_pub_mb, headers["Signature"], "POST", "/inbox", verify_headers
+    ) is False
+
+
+def test_cross_verify_ed25519_sig_with_rsa_key_rejected():
+    """Ed25519 で署名したものを RSA 公開鍵 PEM で検証 → algorithm 不整合で False。"""
+    ed_priv, _ = generate_ed25519_keypair()
+    _, rsa_pub = generate_rsa_keypair()
+    headers = sign_request(
+        ed_priv, "key-id", "POST", "https://remote.example/inbox", algorithm="ed25519"
+    )
+    verify_headers = {k.lower(): v for k, v in headers.items()}
+    assert verify_signature(
+        rsa_pub, headers["Signature"], "POST", "/inbox", verify_headers
+    ) is False
+
+
+def test_hs2019_algorithm_dispatches_by_key_type():
+    """algorithm='hs2019' (曖昧) を受け取った場合、公開鍵の種別から自動判別する。"""
+    # Ed25519 鍵で sign したヘッダの algorithm を 'hs2019' に書き換えて受信側へ渡す
+    ed_priv, ed_pub_mb = generate_ed25519_keypair()
+    headers = sign_request(
+        ed_priv, "key-id", "POST", "https://remote.example/inbox", algorithm="ed25519"
+    )
+    rewritten = headers["Signature"].replace('algorithm="ed25519"', 'algorithm="hs2019"')
+    verify_headers = {k.lower(): v for k, v in headers.items()}
+    verify_headers["signature"] = rewritten
+    assert verify_signature(
+        ed_pub_mb, rewritten, "POST", "/inbox", verify_headers
+    ) is True
+
+
+def test_sign_rsa_algorithm_with_ed25519_key_raises():
+    """algorithm='rsa-sha256' に Ed25519 秘密鍵を渡したら TypeError。"""
+    import pytest
+
+    ed_priv, _ = generate_ed25519_keypair()
+    with pytest.raises(TypeError, match="requires an RSA"):
+        sign_request(
+            ed_priv,
+            "key-id",
+            "POST",
+            "https://remote.example/inbox",
+            algorithm="rsa-sha256",
+        )
+
+
+def test_sign_ed25519_algorithm_with_rsa_key_raises():
+    """algorithm='ed25519' に RSA 秘密鍵を渡したら TypeError。"""
+    import pytest
+
+    rsa_priv, _ = generate_rsa_keypair()
+    with pytest.raises(TypeError, match="requires an Ed25519"):
+        sign_request(
+            rsa_priv,
+            "key-id",
+            "POST",
+            "https://remote.example/inbox",
+            algorithm="ed25519",
+        )

--- a/backend/tests/test_misskey_visibility.py
+++ b/backend/tests/test_misskey_visibility.py
@@ -195,8 +195,8 @@ async def test_render_actor_outputs_misskey_fields(db, mock_valkey):
     assert data["_misskey_makeNotesFollowersOnlyBefore"] == epoch_ms
     assert data["_misskey_makeNotesHiddenBefore"] == epoch_ms
 
-    # Context should include the namespace mappings
-    context_dict = data["@context"][2]
+    # Context should include the namespace mappings (dict entry in AP_CONTEXT list)
+    context_dict = next(entry for entry in data["@context"] if isinstance(entry, dict))
     assert "_misskey_requireSigninToViewContents" in context_dict
     assert "_misskey_makeNotesFollowersOnlyBefore" in context_dict
     assert "_misskey_makeNotesHiddenBefore" in context_dict

--- a/backend/tests/test_renderer.py
+++ b/backend/tests/test_renderer.py
@@ -2,16 +2,13 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 from app.activitypub.renderer import (
-    render_accept_activity,
     render_actor,
     render_create_activity,
-    render_delete_activity,
     render_emoji_react_activity,
     render_follow_activity,
     render_like_activity,
     render_note,
     render_ordered_collection,
-    render_ordered_collection_page,
     render_undo_activity,
 )
 
@@ -25,6 +22,8 @@ def _make_actor(**overrides):
         followers_url="http://localhost/users/alice/followers",
         following_url="http://localhost/users/alice/following",
         public_key_pem="PUBLIC_KEY_PEM",
+        public_key_ed25519_multibase=None,
+        key_id_ed25519=None,
         is_cat=False, manually_approves_followers=False, discoverable=True,
         summary=None, avatar_url=None, header_url=None, domain=None,
         fields=None, require_signin_to_view=False,
@@ -63,6 +62,36 @@ def test_render_actor_public_key():
 
     data = render_actor(_make_actor())
     assert data["publicKey"]["id"] == f"{settings.server_url}/users/alice#main-key"
+    assert data["publicKey"]["publicKeyPem"] == "PUBLIC_KEY_PEM"
+
+
+def test_render_actor_multikey_context_included():
+    """@context に FEP-521a Multikey vocabulary が含まれること。"""
+    data = render_actor(_make_actor())
+    assert "https://w3id.org/security/multikey/v1" in data["@context"]
+
+
+def test_render_actor_no_assertion_method_when_ed25519_absent():
+    """Ed25519 鍵未保有のアクター (移行前の状態) は assertionMethod を出さない。"""
+    data = render_actor(_make_actor())
+    assert "assertionMethod" not in data
+
+
+def test_render_actor_assertion_method_when_ed25519_present():
+    """Ed25519 鍵を持つアクターは assertionMethod に Multikey を出力する。"""
+    from app.config import settings
+
+    multibase = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+    data = render_actor(_make_actor(public_key_ed25519_multibase=multibase))
+    assert "assertionMethod" in data
+    assert isinstance(data["assertionMethod"], list)
+    assert len(data["assertionMethod"]) == 1
+    entry = data["assertionMethod"][0]
+    assert entry["type"] == "Multikey"
+    assert entry["id"] == f"{settings.server_url}/users/alice#ed25519-key"
+    assert entry["controller"] == f"{settings.server_url}/users/alice"
+    assert entry["publicKeyMultibase"] == multibase
+    # publicKey (RSA) も依然として出力 (後方互換)
     assert data["publicKey"]["publicKeyPem"] == "PUBLIC_KEY_PEM"
 
 

--- a/backend/tests/test_utils_crypto.py
+++ b/backend/tests/test_utils_crypto.py
@@ -1,6 +1,12 @@
 import pytest
 
-from app.utils.crypto import generate_rsa_keypair
+from app.utils.crypto import (
+    _base58btc_decode,
+    _base58btc_encode,
+    ed25519_multibase_to_public_bytes,
+    generate_ed25519_keypair,
+    generate_rsa_keypair,
+)
 
 
 @pytest.fixture(scope="module")
@@ -32,3 +38,53 @@ def test_each_call_generates_unique_keys():
     pair2 = generate_rsa_keypair()
     assert pair1[0] != pair2[0]
     assert pair1[1] != pair2[1]
+
+
+# ── Ed25519 / Multikey (FEP-521a) ────────────────────────────────────────
+
+
+def test_base58btc_roundtrip():
+    for sample in (b"", b"\x00", b"\x00\x00\xff", b"hello", bytes(range(32))):
+        assert _base58btc_decode(_base58btc_encode(sample)) == sample
+
+
+def test_ed25519_keypair_returns_pem_and_multibase():
+    private_pem, public_multibase = generate_ed25519_keypair()
+    assert isinstance(private_pem, str)
+    assert isinstance(public_multibase, str)
+    assert "-----BEGIN PRIVATE KEY-----" in private_pem
+    # FEP-521a Multikey: 'z' + base58btc(0xED 0x01 + 32 raw bytes) → 'z6Mk...'
+    assert public_multibase.startswith("z6Mk")
+
+
+def test_ed25519_each_call_unique():
+    p1 = generate_ed25519_keypair()
+    p2 = generate_ed25519_keypair()
+    assert p1[0] != p2[0]
+    assert p1[1] != p2[1]
+
+
+def test_ed25519_multibase_to_public_bytes_roundtrip():
+    _, multibase = generate_ed25519_keypair()
+    raw = ed25519_multibase_to_public_bytes(multibase)
+    assert len(raw) == 32
+
+
+def test_ed25519_multibase_rejects_wrong_prefix():
+    # 'z' で始まらない
+    with pytest.raises(ValueError, match="must start with 'z'"):
+        ed25519_multibase_to_public_bytes("notmultibase")
+
+
+def test_ed25519_multibase_rejects_wrong_multicodec():
+    # base58btc decode 後の multicodec が 0xED 0x01 ではない
+    # 例: secp256k1 multicodec (0xE7 0x01) を模した不正な値
+    bogus = "z" + _base58btc_encode(b"\xe7\x01" + b"\x00" * 33)
+    with pytest.raises(ValueError, match="multicodec"):
+        ed25519_multibase_to_public_bytes(bogus)
+
+
+def test_ed25519_multibase_rejects_invalid_base58_char():
+    # base58btc アルファベット外の '0' を含む
+    with pytest.raises(ValueError, match="base58btc"):
+        ed25519_multibase_to_public_bytes("z6Mk0invalid")


### PR DESCRIPTION
## Summary
- ActivityPub HTTP Signature に Ed25519 を追加対応 (Fedibird / Mitra 等が要求する FEP-521a Multikey 形式)。
- 各ローカルアクターは **RSA と Ed25519 を並行保持** する dual-key 構成。`publicKey` (RSA, cavage) は据え置きで Mastodon / Misskey 互換、Ed25519 は `assertionMethod[]` の Multikey で *追加* 公開。
- 既存ローカル User は **Alembic 044** で一括 backfill (RSA 鍵は触らない)。
- 送信時は配送先 actor が Ed25519 capable なら Ed25519 で署名、未対応相手は RSA フォールバック。
- FEP-8b32 (Object Integrity Proofs) は対象外。

closes #1040

## Changes
| Layer | File | 内容 |
|---|---|---|
| utils | `app/utils/crypto.py` | `generate_ed25519_keypair`、`ed25519_multibase_to_public_bytes`、base58btc 自前実装 |
| models | `app/models/actor.py`、`app/models/user.py` | Ed25519 用 nullable カラム 3 つ追加 |
| migration | `alembic/versions/044_add_ed25519_keys.py` | カラム追加 + 既存ローカル User 全員に backfill |
| http_signature | `app/activitypub/http_signature.py` | `sign_request(..., algorithm=)` 引数追加、`verify_signature` を hs2019 寛容受理に拡張、`_parse_public_key_multibase` 追加 |
| renderer | `app/activitypub/renderer.py` | `AP_CONTEXT` に `https://w3id.org/security/multikey/v1`、`assertionMethod[]` 出力 |
| services | `app/services/actor_service.py` | `upsert_remote_actor` で Multikey 抽出、`get_actor_public_key` を `(actor, material, algorithm)` の 3-tuple に拡張 |
| services | `app/services/user_service.py`、`system_account_service.py` | 新規ユーザー作成・システムアカウント補完で Ed25519 鍵も生成 |
| routes | `app/activitypub/routes.py` | inbox 検証で algorithm hint を渡す |
| worker | `app/worker/delivery_worker.py` | `_signing_key_cache` 拡張、相手 actor の Ed25519 capability 検出、algorithm ディスパッチ |

## Interop policy
- 送信: 相手 actor が `public_key_ed25519_multibase` を持てば Ed25519、なければ RSA フォールバック
- 受信: HTTP Signature `algorithm` が `ed25519` / `rsa-sha256` / `hs2019` (鍵種別から推論) / 空 を受理
- 鍵種別と algorithm の不整合は厳格に拒否 (RSA 公開鍵で Ed25519 sig を検証 → False)

## Test plan
- [x] `pytest tests/test_utils_crypto.py tests/test_http_signature.py tests/test_renderer.py` (host) — 47 件全 pass
- [ ] CI で `test_actor_service_extended` / `test_delivery_worker` (PostgreSQL 必須) 通過
- [ ] CI 全 job pass
- [ ] Devin Review / nekonaudit findings の確認
- [ ] **マージ後**、Federation E2E をローカルで実行:
  - `docker compose -f docker-compose.federation.yml ...` — 自鯖同士で Ed25519 配送
  - `docker compose -f docker-compose.fedibird-federation.yml ...` — Fedibird との双方向 Ed25519
  - `docker compose -f docker-compose.mitra-federation.yml ...` — Mitra との双方向 Ed25519
  - `docker compose -f docker-compose.mastodon-federation.yml ...` — Mastodon との RSA フォールバック回帰
  - `docker compose -f docker-compose.misskey-federation.yml ...` — Misskey との RSA 回帰

🤖 Generated with [Claude Code](https://claude.com/claude-code)