### PR TITLE
feat: actors の inbox_url 系 index を CREATE INDEX CONCURRENTLY 化 (#1042)

### DIFF
--- a/backend/alembic/versions/045_concurrent_actor_inbox_indexes.py
+++ b/backend/alembic/versions/045_concurrent_actor_inbox_indexes.py
@@ -1,0 +1,79 @@
+"""actors の inbox_url / shared_inbox_url index を CREATE INDEX CONCURRENTLY 化する。
+
+issue #1042: 044 で追加した通常 index を drop し、CONCURRENTLY で再作成する。
+大規模 instance (actors 10 万行+) における migration の ACCESS EXCLUSIVE
+ロック時間を SHARE UPDATE EXCLUSIVE に抑え、配送・WebFinger 等の actors
+読み取りを邪魔せず index 構築できるようにする。
+
+注意:
+- CONCURRENTLY は transaction 外で実行する必要があるため autocommit_block でラップ。
+- migration が中断すると INVALID index が残る可能性 (Postgres 仕様)。
+  リカバリ手順は docs/deploy.md を参照。
+- CI は Base.metadata.create_all で初期化するため、本 migration は CI で走らない。
+  ローカルの `alembic upgrade head` / `downgrade -1` 往復で検証すること。
+
+Revision ID: 045
+Revises: 044
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "045"
+down_revision = "044"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_actors_inbox_url",
+            table_name="actors",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_actors_shared_inbox_url",
+            table_name="actors",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.create_index(
+            "ix_actors_inbox_url",
+            "actors",
+            ["inbox_url"],
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_actors_shared_inbox_url",
+            "actors",
+            ["shared_inbox_url"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("shared_inbox_url IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    # CONCURRENTLY で削除してから 044 状態 (通常 index) で再作成する。
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_actors_shared_inbox_url",
+            table_name="actors",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_actors_inbox_url",
+            table_name="actors",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+    op.create_index("ix_actors_inbox_url", "actors", ["inbox_url"])
+    op.create_index(
+        "ix_actors_shared_inbox_url",
+        "actors",
+        ["shared_inbox_url"],
+        postgresql_where=sa.text("shared_inbox_url IS NOT NULL"),
+    )

--- a/backend/alembic/versions/045_concurrent_actor_inbox_indexes.py
+++ b/backend/alembic/versions/045_concurrent_actor_inbox_indexes.py
@@ -60,16 +60,16 @@ def upgrade() -> None:
 def downgrade() -> None:
     # 巻き戻しでも ACCESS EXCLUSIVE を取らないよう、再作成も CONCURRENTLY で行う。
     # 044 とは index 種別が同等 (機能的に同一の B-tree) なので、運用上 044 完全一致
-    # である必要はない。
+    # である必要はない。drop/create の順序は upgrade と揃える (inbox_url → shared)。
     with op.get_context().autocommit_block():
         op.drop_index(
-            "ix_actors_shared_inbox_url",
+            "ix_actors_inbox_url",
             table_name="actors",
             postgresql_concurrently=True,
             if_exists=True,
         )
         op.drop_index(
-            "ix_actors_inbox_url",
+            "ix_actors_shared_inbox_url",
             table_name="actors",
             postgresql_concurrently=True,
             if_exists=True,

--- a/backend/alembic/versions/045_concurrent_actor_inbox_indexes.py
+++ b/backend/alembic/versions/045_concurrent_actor_inbox_indexes.py
@@ -28,6 +28,8 @@ depends_on = None
 
 def upgrade() -> None:
     with op.get_context().autocommit_block():
+        # drop は CONCURRENTLY + IF EXISTS で冪等。中断で INVALID index が
+        # 残った状態で再 apply されても、ここで INVALID も含めて巻き取られる。
         op.drop_index(
             "ix_actors_inbox_url",
             table_name="actors",
@@ -56,7 +58,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # CONCURRENTLY で削除してから 044 状態 (通常 index) で再作成する。
+    # 巻き戻しでも ACCESS EXCLUSIVE を取らないよう、再作成も CONCURRENTLY で行う。
+    # 044 とは index 種別が同等 (機能的に同一の B-tree) なので、運用上 044 完全一致
+    # である必要はない。
     with op.get_context().autocommit_block():
         op.drop_index(
             "ix_actors_shared_inbox_url",
@@ -70,10 +74,16 @@ def downgrade() -> None:
             postgresql_concurrently=True,
             if_exists=True,
         )
-    op.create_index("ix_actors_inbox_url", "actors", ["inbox_url"])
-    op.create_index(
-        "ix_actors_shared_inbox_url",
-        "actors",
-        ["shared_inbox_url"],
-        postgresql_where=sa.text("shared_inbox_url IS NOT NULL"),
-    )
+        op.create_index(
+            "ix_actors_inbox_url",
+            "actors",
+            ["inbox_url"],
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_actors_shared_inbox_url",
+            "actors",
+            ["shared_inbox_url"],
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("shared_inbox_url IS NOT NULL"),
+        )


### PR DESCRIPTION
## Summary
- migration 044 で追加した `ix_actors_inbox_url` / `ix_actors_shared_inbox_url` を、新規 migration 045 で drop して CREATE INDEX CONCURRENTLY 版に rebuild。
- 大規模 instance (actors 10 万行+) で migration の `ACCESS EXCLUSIVE` ロックが配送・WebFinger を長時間止めていた問題に対処。CONCURRENTLY によりロックは `SHARE UPDATE EXCLUSIVE` に弱まり、index 構築中も読み取りは邪魔されない。
- nekonoverse の alembic で `autocommit_block` / `postgresql_concurrently` を使う最初のパターン。

closes #1042

## Background
PR #1041 (Ed25519 対応) で 044 に部分 index を 2 つ追加したが、ACCESS EXCLUSIVE ロックの懸念を nekonaudit から指摘 (round 2)。本 PR はその tracking issue #1042 への対応。

## 実装
- `with op.get_context().autocommit_block():` でラップして transaction 外で実行 (CONCURRENTLY は transaction 内で実行不可)。
- drop は `postgresql_concurrently=True` + `if_exists=True` で冪等化 (045 再 apply 時、もしくは中断で INVALID index が残った場合も自動回収)。
- downgrade も CONCURRENTLY で drop & create (巻き戻し時にも ACCESS EXCLUSIVE を取らない)。
- env.py は変更不要 (`autocommit_block` は async engine + `run_sync` 構成でも動作)。

## 検証
- [x] `alembic upgrade 044:045 --sql` で SQL 生成: `BEGIN` の合間に `DROP/CREATE INDEX CONCURRENTLY` が正しく出ることを確認。
- [x] `alembic downgrade 045:044 --sql` でも CONCURRENTLY で drop & create が生成。
- [x] **実機検証 (docker-compose.e2e.yml)** — `alembic upgrade head` → `downgrade -1` → `upgrade head` の往復で index が正しく rebuild される。実行ログ:
  ```
  $ alembic current
  045 (head)
  $ alembic downgrade -1
  Running downgrade 045 -> 044, actors の inbox_url ... CREATE INDEX CONCURRENTLY 化する。
  $ \d actors の index 確認 (downgrade 後)
   ix_actors_inbox_url        | CREATE INDEX ix_actors_inbox_url ON public.actors USING btree (inbox_url)
   ix_actors_shared_inbox_url | CREATE INDEX ix_actors_shared_inbox_url ON public.actors USING btree (shared_inbox_url) WHERE (shared_inbox_url IS NOT NULL)
  $ alembic upgrade head
  Running upgrade 044 -> 045, ... CREATE INDEX CONCURRENTLY 化する。
  $ \d actors の index 確認 (再 upgrade 後) → 同じ index 定義で再構築
  ```
  async engine + `run_sync` + `autocommit_block` の組み合わせで AUTOCOMMIT 切替が正しく伝播することを確認。

## 残課題 (tracking issues)
- #1044 — CI に `alembic upgrade --sql` の軽量 dry-run job を追加
- #1045 — `docs/deploy.md` に CONCURRENTLY migration の運用ガイド (失敗時リカバリ、実行中の一時的シーケンシャルスキャン) を追記

## 失敗時のリカバリ手順 (詳細は #1045)
CONCURRENTLY 中断で INVALID index が残った場合:
```sql
SELECT indexname FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
  WHERE NOT i.indisvalid AND c.relname LIKE 'ix_actors_%';
DROP INDEX CONCURRENTLY <indexname>;
-- alembic を再実行 (045 upgrade 冒頭の DROP INDEX CONCURRENTLY IF EXISTS で自動回収される)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)