### PR TITLE
chore: alembic migration roundtrip CI + CONCURRENTLY 運用ガイド (#1044, #1045)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,68 @@ jobs:
           REGISTRATION_OPEN: "true"
         run: python -m pytest tests/ -v -n auto --shard-id=${{ matrix.shard }} --num-shards=4
 
+  alembic-migration:
+    # 実 PostgreSQL に対して `alembic upgrade head` → `downgrade base` → `upgrade head`
+    # の往復を実行し、migration の構文ミス・revision chain の不整合・autocommit_block
+    # + CONCURRENTLY 系の互換性を検出する。pytest は Base.metadata.create_all で初期化
+    # するため migration 自体は走らない (#1044)。
+    runs-on: ubuntu-latest
+    name: Alembic migration roundtrip
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: nekonoverse
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: nekonoverse_mig
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pip install -e ".[dev]"
+
+      - name: alembic upgrade head
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql+asyncpg://nekonoverse:testpass@localhost:5432/nekonoverse_mig
+          VALKEY_URL: valkey://localhost:6379/0
+          DOMAIN: localhost
+          SECRET_KEY: dummy
+          DEBUG: "false"
+        run: PYTHONPATH=. alembic upgrade head
+
+      - name: alembic downgrade base (full reverse)
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql+asyncpg://nekonoverse:testpass@localhost:5432/nekonoverse_mig
+          VALKEY_URL: valkey://localhost:6379/0
+          DOMAIN: localhost
+          SECRET_KEY: dummy
+          DEBUG: "false"
+        run: PYTHONPATH=. alembic downgrade base
+
+      - name: alembic upgrade head (re-apply)
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql+asyncpg://nekonoverse:testpass@localhost:5432/nekonoverse_mig
+          VALKEY_URL: valkey://localhost:6379/0
+          DOMAIN: localhost
+          SECRET_KEY: dummy
+          DEBUG: "false"
+        run: PYTHONPATH=. alembic upgrade head
+
   frontend-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,13 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    env:
+      DATABASE_URL: postgresql+asyncpg://nekonoverse:testpass@localhost:5432/nekonoverse_mig
+      DOMAIN: localhost
+      SECRET_KEY: test-secret-key
+      DEBUG: "true"
+      # 注: valkey service は不要 (alembic は Valkey に接続しない)。
+      #     env.py が将来 Valkey 接続を import した場合に備えて URL は設定しない。
     steps:
       - uses: actions/checkout@v4
 
@@ -108,32 +115,14 @@ jobs:
 
       - name: alembic upgrade head
         working-directory: backend
-        env:
-          DATABASE_URL: postgresql+asyncpg://nekonoverse:testpass@localhost:5432/nekonoverse_mig
-          VALKEY_URL: valkey://localhost:6379/0
-          DOMAIN: localhost
-          SECRET_KEY: dummy
-          DEBUG: "false"
         run: PYTHONPATH=. alembic upgrade head
 
       - name: alembic downgrade base (full reverse)
         working-directory: backend
-        env:
-          DATABASE_URL: postgresql+asyncpg://nekonoverse:testpass@localhost:5432/nekonoverse_mig
-          VALKEY_URL: valkey://localhost:6379/0
-          DOMAIN: localhost
-          SECRET_KEY: dummy
-          DEBUG: "false"
         run: PYTHONPATH=. alembic downgrade base
 
       - name: alembic upgrade head (re-apply)
         working-directory: backend
-        env:
-          DATABASE_URL: postgresql+asyncpg://nekonoverse:testpass@localhost:5432/nekonoverse_mig
-          VALKEY_URL: valkey://localhost:6379/0
-          DOMAIN: localhost
-          SECRET_KEY: dummy
-          DEBUG: "false"
         run: PYTHONPATH=. alembic upgrade head
 
   frontend-build:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -46,11 +46,19 @@ docker compose -f docker-compose.prod.yml up -d
 
 - ロックレベルは `SHARE UPDATE EXCLUSIVE` に弱まり、配送・WebFinger 等の `actors` 読み取り SELECT は **ブロックされない**。
 - ただし drop → create の **間に該当 index が一時的に存在しないウィンドウ** が発生し、その間 `inbox_url` / `shared_inbox_url` ルックアップはシーケンシャルスキャンになる。大規模 instance (actors 10 万行+) で配送遅延が一時的に増える可能性があるため、**メンテナンスウィンドウ中の実行を推奨**。
-- 1 ブロック (`autocommit_block`) 内で drop ×2 + create ×2 が連続実行されるため、所要時間は actors 行数に比例 (100 万行で数十秒〜数分)。
+- 1 ブロック (`autocommit_block`) 内で対象 index (`ix_actors_inbox_url` / `ix_actors_shared_inbox_url`) の drop ×2 + create ×2 が連続実行されるため、所要時間は actors 行数に比例 (100 万行で数十秒〜数分)。
 
 ### 失敗時のリカバリ手順
 
-`CREATE INDEX CONCURRENTLY` は途中で中断されると **INVALID index が残る** (Postgres 仕様)。発見と削除:
+`CREATE INDEX CONCURRENTLY` は途中で中断されると **INVALID index が残る** (Postgres 仕様)。
+
+**通常は alembic 再実行だけで自動回収できる** — 045 以降の upgrade 冒頭で `DROP INDEX CONCURRENTLY IF EXISTS ix_actors_inbox_url` / `ix_actors_shared_inbox_url` が走るため、INVALID 状態の index も含めて drop してから create し直す:
+
+```bash
+docker compose exec app alembic upgrade head
+```
+
+**自動回収できない場合 (alembic を再実行しても解消しない、別 index に INVALID が残った等)** は INVALID index を手動で発見・削除してから再実行:
 
 ```sql
 -- 1. INVALID index を発見
@@ -60,15 +68,9 @@ SELECT c.relname
 
 -- 2. INVALID index を削除 (CONCURRENTLY で他クエリを止めない)
 DROP INDEX CONCURRENTLY <indexname>;
-
--- 3. alembic を再実行
--- 045 以降の upgrade 冒頭で `DROP INDEX CONCURRENTLY IF EXISTS` が走るため、
--- INVALID が残っていても再 apply で自動回収される。
 ```
 
-```bash
-docker compose exec app alembic upgrade head
-```
+その後 `alembic upgrade head` を再実行する。
 
 ### 注意
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -38,6 +38,46 @@ docker compose -f docker-compose.prod.yml up -d
 
 ---
 
+## CONCURRENTLY マイグレーションの運用ガイド
+
+`backend/alembic/versions/045_concurrent_actor_inbox_indexes.py` 以降、大規模テーブル (actors 等) への index 追加・rebuild は `CREATE INDEX CONCURRENTLY` を使う migration が混在する。通常 migration とは挙動が違うので運用時の留意点を以下にまとめる。
+
+### 実行中の挙動
+
+- ロックレベルは `SHARE UPDATE EXCLUSIVE` に弱まり、配送・WebFinger 等の `actors` 読み取り SELECT は **ブロックされない**。
+- ただし drop → create の **間に該当 index が一時的に存在しないウィンドウ** が発生し、その間 `inbox_url` / `shared_inbox_url` ルックアップはシーケンシャルスキャンになる。大規模 instance (actors 10 万行+) で配送遅延が一時的に増える可能性があるため、**メンテナンスウィンドウ中の実行を推奨**。
+- 1 ブロック (`autocommit_block`) 内で drop ×2 + create ×2 が連続実行されるため、所要時間は actors 行数に比例 (100 万行で数十秒〜数分)。
+
+### 失敗時のリカバリ手順
+
+`CREATE INDEX CONCURRENTLY` は途中で中断されると **INVALID index が残る** (Postgres 仕様)。発見と削除:
+
+```sql
+-- 1. INVALID index を発見
+SELECT c.relname
+  FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+ WHERE NOT i.indisvalid AND c.relname LIKE 'ix_actors_%';
+
+-- 2. INVALID index を削除 (CONCURRENTLY で他クエリを止めない)
+DROP INDEX CONCURRENTLY <indexname>;
+
+-- 3. alembic を再実行
+-- 045 以降の upgrade 冒頭で `DROP INDEX CONCURRENTLY IF EXISTS` が走るため、
+-- INVALID が残っていても再 apply で自動回収される。
+```
+
+```bash
+docker compose exec app alembic upgrade head
+```
+
+### 注意
+
+- migration 中に `Ctrl-C` で中断すると上記の INVALID 状態に至りやすい。**完了まで止めない**こと。
+- `alembic downgrade -1` も同じ CONCURRENTLY 経路で巻き戻る (045 以降)。downgrade 中の中断も同様にリカバリ手順が必要。
+- ローカル開発 (`docker-compose.e2e.yml`) では actors が空〜数行なので ms オーダーで完了する。本番のみ留意。
+
+---
+
 ## Docker を使わない場合
 
 Docker を使わずに各サービスを直接ホスト上で動かす構成。


### PR DESCRIPTION
## Summary
- **#1044**: `alembic upgrade head → downgrade base → upgrade head` の往復を実 PostgreSQL で実行する `alembic-migration` job を `test.yml` に追加。pytest は `Base.metadata.create_all` で初期化するため migration が CI で走らない穴を塞ぐ。`autocommit_block + CONCURRENTLY` 系の互換性検証も兼ねる。
- **#1045**: `docs/deploy.md` に CONCURRENTLY migration の運用ガイド (挙動、INVALID index リカバリ手順、注意) を追記。

closes #1044
closes #1045

## なぜ実 DB 経路を選んだか
当初 `alembic upgrade head --sql` の軽量 dry-run を目指したが、既存の migration 025 が `--sql` モードで `connection.execute(...).first()` を呼ぶため offline モードで `AttributeError` になる (本 PR とは独立した既存問題)。025 を全て `--sql` 対応に書き直すのは別 issue 規模になるため、実 DB を使った往復 job で同等の検証ができる方針に切替えた。実 DB なら CONCURRENTLY も実走するので 045 の autocommit_block 互換性も自動で検証される。

## Test plan
- [x] yaml syntax 検証
- [ ] CI で `alembic-migration` job が green (本 PR 自身で実証)
- [ ] mkdocs build (`docs.yml`) が strict pass
- [ ] 既存の backend-test / e2e-test 等が回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)