### PR TITLE
chore: リリース 20260524-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [20260524-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260524-1) — 2026-05-24
+
+### CI / 運用ドキュメント
+
+- **Alembic migration roundtrip CI job を追加** — `alembic upgrade head → downgrade base → upgrade head` の往復を実 PostgreSQL に対して実行する job を `test.yml` に追加。pytest は `Base.metadata.create_all` で初期化するため migration 自体は CI で走らない穴を塞ぐ。`autocommit_block + postgresql_concurrently=True` の互換性も毎 PR で自動検証される (#1044, #1049)
+- **docs/deploy.md に CONCURRENTLY migration の運用ガイドを追記** — 実行中の挙動 (ロックレベル、一時的 index 不在ウィンドウ、所要時間目安)、失敗時のリカバリ手順 (INVALID index の検出と `DROP INDEX CONCURRENTLY`)、運用上の注意 (中断しないこと、downgrade 中断時も同様) を記載 (#1045, #1049)
+
+---
+
 ## [20260520-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260520-1) — 2026-05-20
 
 ### セキュリティ

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260520-1"
+__version__ = "20260524-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260520-1"
+version = "20260524-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "nekonoverse"
-version = "20260520.post1"
+version = "20260524.post1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260520-1",
+  "version": "20260524-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260520-1",
+      "version": "20260524-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260520-1",
+  "version": "20260524-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- 20260524-1 用 version bump + CHANGELOG エントリ追加。
- 含まれる変更:
  - #1044 / #1045 / #1049 — Alembic migration roundtrip CI + CONCURRENTLY 運用ガイド

## Test plan
- [ ] CI 通過
- [ ] マージ後、release PR (`develop → main`) を別途作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)