### PR TITLE
docs: 連合テスト手順を run --build に修正 (#1052)

### DIFF
--- a/docker-compose.fedibird-federation.yml
+++ b/docker-compose.fedibird-federation.yml
@@ -4,9 +4,9 @@
 #   # 初回のみ: Fedibirdイメージのビルド（5-10分かかる）
 #   docker compose -f docker-compose.fedibird-federation.yml build fedibird-web
 #
-#   # テスト実行
+#   # テスト実行 (run には --build を必須で付ける。理由は claude-md/CLAUDE.md の Federation 節)
 #   docker compose -f docker-compose.fedibird-federation.yml up -d --build --wait
-#   docker compose -f docker-compose.fedibird-federation.yml run --rm test-runner
+#   docker compose -f docker-compose.fedibird-federation.yml run --build --rm test-runner
 #   docker compose -f docker-compose.fedibird-federation.yml down -v
 
 services:


### PR DESCRIPTION
## Summary

- CLAUDE.md (submodule) の Misskey/Mastodon/Mitra 連合テスト実行コマンドを `run --rm test-runner` から `run --build --rm test-runner` に修正
- 修正理由を解説する注記を追加
- 追補: fedibird compose の Usage コメントを同じ表記に揃える + cross-reference
- 追補: CLAUDE.md の PR レビュー手順を「Devin Review」から「nekonaudit」に更新
- Plan: #1052

## 背景

複数 variant の連合テストを連続実行すると、2 個目以降が必ず失敗する問題があった (2026-05-30 に develop で踏んで確認済み)。

**原因の流れ**:
1. 5 つの compose で test-runner は `profiles: ["test"]` のため `up -d --build --wait` ではビルドされない
2. 初回 `run --rm test-runner` で `nekonoverse-test-runner:latest` がビルドされる
3. compose project 名がすべて親ディレクトリ名 `nekonoverse` で共通のため、image tag も共通
4. `down -v` は volume/container/network を消すがイメージは残す
5. 次の variant の `run` は build context が変わっていても既存イメージを再利用するため、最初の variant のテストファイルがそのまま走る
6. 例: Misskey → Mastodon の順で実行すると Mastodon 環境で `test_misskey_federation.py` が走り、存在しない `https://misskey` のヘルスチェックでタイムアウトする

## 修正内容

`run` に `--build` を付ければ `docker compose run` が必ず再ビルドするので、variant 間のイメージ汚染を防げる。CLAUDE.md の手順を以下に変更:

```diff
- docker compose -f docker-compose.X-federation.yml run --rm test-runner
+ docker compose -f docker-compose.X-federation.yml run --build --rm test-runner
```

加えて、なぜ `--build` が必要かを後続の箇条書きで補足。

## 確認

2026-05-30 にローカルで再実行し、`run --build` 版で 5 種類すべて連続グリーンを確認:

| Variant | テスト数 |
|---|---|
| Misskey | 56 passed |
| Mastodon | 37 passed |
| Mitra | 26 passed (+ 1 xfailed) |
| Pleroma | 20 passed |
| Fedibird | 39 passed |

## Test plan

- [x] ローカルで 5 variant 連続実行してすべてグリーンを確認 (2026-05-30)
- [x] CI 全 18 job グリーン (Alembic / CodeQL / Analyze x3 / backend-test x4 / e2e-build / e2e-test x3 / federation-test / frontend-build / mastodon-client-test / review)
- [x] nekonaudit のレビュー findings 確認 (3 回 approve、Minor 指摘 1 件は対応済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)