### PR TITLE
fix: Web Push 失敗時にプッシュサービス応答本文をログに残す (#1054)

### DIFF
--- a/backend/app/services/push_service.py
+++ b/backend/app/services/push_service.py
@@ -6,6 +6,7 @@ import hmac
 import json
 import logging
 import uuid
+from urllib.parse import urlsplit
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -271,13 +272,24 @@ async def send_web_push(
                 vapid_claims=vapid_claims,
             )
         except WebPushException as e:
+            response = getattr(e, "response", None)
+            status = getattr(response, "status_code", None) if response is not None else None
+
             # 410 Gone = 購読が無効 → 自動削除
-            if hasattr(e, "response") and e.response is not None and e.response.status_code == 410:
+            if status == 410:
                 stale_ids.append(sub.id)
-            else:
-                logger.warning("Web Push failed for %s: %s", sub.endpoint, e)
+                continue
+
+            # 4xx/5xx の応答本文はプッシュサービス (Apple/Mozilla/FCM) の
+            # 具体的な拒否理由を含む。推測ベースのデバッグを避けるため
+            # status と本文の先頭をログに残す。
+            _log_web_push_failure(sub.endpoint, response, e)
         except Exception as e:
-            logger.warning("Web Push unexpected error for %s: %s", sub.endpoint, e)
+            logger.warning(
+                "Web Push unexpected error: host=%s error=%s",
+                _endpoint_host(sub.endpoint),
+                e,
+            )
 
     # 無効な購読を一括削除
     if stale_ids:
@@ -285,6 +297,41 @@ async def send_web_push(
             delete(PushSubscription).where(PushSubscription.id.in_(stale_ids))
         )
         await db.flush()
+
+
+def _endpoint_host(endpoint: str) -> str:
+    """endpoint URL からホスト部分のみを取り出す (ログでの PII / 検索性配慮)。"""
+    try:
+        return urlsplit(endpoint).hostname or endpoint
+    except ValueError:
+        return endpoint
+
+
+def _log_web_push_failure(endpoint: str, response, error: Exception) -> None:
+    """WebPushException 発生時にプッシュサービスからの応答本文を含めてログする。
+
+    Apple (web.push.apple.com) などは status だけでなく本文に具体的な拒否理由を
+    返す。response が取れない場合は例外メッセージで代替する。
+    """
+    host = _endpoint_host(endpoint)
+    if response is None:
+        logger.warning("Web Push failed: host=%s error=%s", host, error)
+        return
+
+    status = getattr(response, "status_code", None)
+    body_excerpt = ""
+    try:
+        text = response.text
+        if text:
+            body_excerpt = text[:500]
+    except Exception:
+        body_excerpt = "<unavailable>"
+    logger.warning(
+        "Web Push failed: host=%s status=%s body=%s",
+        host,
+        status,
+        body_excerpt,
+    )
 
 
 def _build_title(notification_type: str, sender_name: str | None) -> str:

--- a/backend/app/services/push_service.py
+++ b/backend/app/services/push_service.py
@@ -285,10 +285,13 @@ async def send_web_push(
             # status と本文の先頭をログに残す。
             _log_web_push_failure(sub.endpoint, response, e)
         except Exception as e:
+            # pywebpush 外の予期せぬ例外は本 PR の観測強化対象外だが、
+            # スタックトレースが無いと後から追えないので exc_info も残す
             logger.warning(
                 "Web Push unexpected error: host=%s error=%s",
                 _endpoint_host(sub.endpoint),
                 e,
+                exc_info=True,
             )
 
     # 無効な購読を一括削除

--- a/backend/app/services/push_service.py
+++ b/backend/app/services/push_service.py
@@ -307,7 +307,9 @@ def _endpoint_host(endpoint: str) -> str:
         return endpoint
 
 
-def _log_web_push_failure(endpoint: str, response, error: Exception) -> None:
+def _log_web_push_failure(
+    endpoint: str, response: object | None, error: Exception
+) -> None:
     """WebPushException 発生時にプッシュサービスからの応答本文を含めてログする。
 
     Apple (web.push.apple.com) などは status だけでなく本文に具体的な拒否理由を
@@ -321,10 +323,12 @@ def _log_web_push_failure(endpoint: str, response, error: Exception) -> None:
     status = getattr(response, "status_code", None)
     body_excerpt = ""
     try:
-        text = response.text
+        text = getattr(response, "text", None)
         if text:
             body_excerpt = text[:500]
     except Exception:
+        # 「なぜ body が unavailable だったか」を後から追えるよう原因も残す
+        logger.debug("Failed to read Web Push response body", exc_info=True)
         body_excerpt = "<unavailable>"
     logger.warning(
         "Web Push failed: host=%s status=%s body=%s",

--- a/backend/tests/test_push.py
+++ b/backend/tests/test_push.py
@@ -348,6 +348,51 @@ async def test_send_web_push_removes_stale_410(db, test_user):
 
 
 
+async def test_send_web_push_logs_response_body_on_4xx(db, test_user, caplog):
+    """4xx 時はプッシュサービス応答の status と本文をログに出す (iPhone PWA 通知不調の調査用)。"""
+    import logging
+
+    from pywebpush import WebPushException
+
+    from app.services.push_service import create_subscription, send_web_push
+
+    await create_subscription(
+        db,
+        actor_id=test_user.actor_id,
+        session_id="sess-4xx",
+        endpoint="https://web.push.apple.com/AAAA/BBBB",
+        key_p256dh="key",
+        key_auth="auth",
+    )
+    await db.commit()
+
+    mock_response = type(
+        "Response",
+        (),
+        {"status_code": 403, "text": "BadJwtToken: Vapid sub claim invalid"},
+    )()
+    error = WebPushException("Forbidden", response=mock_response)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="app.services.push_service"),
+        patch("pywebpush.webpush", side_effect=error),
+        patch("app.services.push_service.is_push_enabled", return_value=True),
+    ):
+        await send_web_push(
+            db,
+            recipient_id=test_user.actor_id,
+            notification_type="follow",
+            sender_display_name="Alice",
+        )
+
+    records = [r.getMessage() for r in caplog.records if r.name == "app.services.push_service"]
+    assert any("status=403" in m for m in records), records
+    assert any("BadJwtToken" in m for m in records), records
+    # endpoint URL 全体ではなく host だけが出ること (path 部分はトークンを含むので)
+    assert any("host=web.push.apple.com" in m for m in records), records
+    assert not any("AAAA/BBBB" in m for m in records), records
+
+
 async def test_send_web_push_policy_filter(db, test_user, test_user_b):
     """Push with policy='followed' should only send if recipient follows sender."""
     from app.services.push_service import create_subscription, send_web_push


### PR DESCRIPTION
## Summary

- `WebPushException` 発生時に応答 status と本文の先頭 500 文字を WARNING ログに出すよう改修
- endpoint は `host` のみログに出力 (path に含まれる push token を漏らさない)
- 410 Gone の自動削除挙動は維持
- Plan: #1054

## 背景

iPhone PWA で Web Push 通知が一切届かない (PC ブラウザでは届く) という報告。原因の切り分けに必要な情報が現状のログには出ていない:

```python
# 旧
logger.warning("Web Push failed for %s: %s", sub.endpoint, e)
```

これでは「失敗した」ことしか分からず、Apple (`web.push.apple.com`) が何で蹴っているのか (例: `BadJwtToken`, `InvalidSubscription`) が見えない。Apple は具体的な拒否理由を **HTTP 応答本文** に返すので、これをログに残せば次に iPhone でテストしたときに原因が一発で観測できる。

参考: noticord 743a41bddd50abbaad46a2af8431420461ea4159 — webpush-go の VAPID `sub` 二重 mailto バグを「応答本文ログ追加」で特定した事例。

## 修正内容

```python
# 新
except WebPushException as e:
    response = getattr(e, "response", None)
    status = getattr(response, "status_code", None) if response is not None else None

    if status == 410:
        stale_ids.append(sub.id)
        continue

    _log_web_push_failure(sub.endpoint, response, e)
```

`_log_web_push_failure` は:
- response が取れる場合: `Web Push failed: host=web.push.apple.com status=403 body=BadJwtToken: ...`
- 取れない場合: `Web Push failed: host=web.push.apple.com error=<exception message>`

endpoint は `urlsplit().hostname` で host だけにする (path には push token が含まれるため、検索性/PII の観点でログには出さない)。

## なぜ noticord の本丸 (`sub` 二重 mailto) は今回入れないか

pywebpush (Python) は webpush-go と違い、`sub` を auto-prepend しない。`_get_vapid_claims()` が返す `{"sub": "mailto:admin@<domain>"}` は py-vapid にそのまま渡されて JWT 化されるので、二重 mailto は構造上発生しない。同じ罠は無いので、いきなり同じ修正を移植するのは早合点。**まず観測** → 事実を見て次の手を決める方針。

## Test plan

- [x] 新規テスト `test_send_web_push_logs_response_body_on_4xx` で:
  - mock `WebPushException(status_code=403, text="BadJwtToken: ...")` を発生させたとき
  - ログレコードに `status=403`, `BadJwtToken`, `host=web.push.apple.com` が含まれる
  - endpoint path 部 (`AAAA/BBBB`) が含まれない
- [x] 既存 `test_send_web_push_removes_stale_410` (410 自動削除) がそのまま pass
- [ ] CI 全体 pass
- [ ] nekonaudit のレビュー確認

## やらないこと

- VAPID 鍵/claims 生成ロジックの変更 (観測前の推測修正を避ける)
- フロント (`sw.ts` / manifest / アイコン) の変更
- ログ強化後の iPhone 実機テストでの追跡 → 別 PR/Issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)