### PR TITLE
fix: VAPID 秘密鍵を base64url(raw 32 バイト) で pywebpush に渡す (#1056)

### DIFF
--- a/backend/app/services/push_service.py
+++ b/backend/app/services/push_service.py
@@ -95,16 +95,16 @@ def _get_vapid_claims() -> dict:
     }
 
 
-def _get_vapid_private_key_pem() -> str:
-    """pywebpush 用に VAPID 秘密鍵を PEM 文字列として取得する。"""
-    from cryptography.hazmat.primitives import serialization
+def _get_vapid_private_key_base64url() -> str:
+    """pywebpush 用に VAPID 秘密鍵を base64url(raw 32 バイト) で取得する。
 
-    ec_key = _private_key_to_ec()
-    return ec_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    ).decode()
+    pywebpush (py_vapid) の Vapid.from_string() は引数を base64url decode し、
+    長さが 32 バイトなら from_raw()、そうでなければ from_der() を試みる。
+    PEM 文字列を渡すと from_der() に落ちて ASN.1 parse error になるため、
+    必ず raw 鍵の base64url 形式 (=43 文字) を渡す。
+    """
+    raw = _get_vapid_private_key_bytes()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
 
 
 # --- 購読 CRUD ---
@@ -235,7 +235,7 @@ async def send_web_push(
 
     from pywebpush import WebPushException, webpush
 
-    vapid_private_key_pem = _get_vapid_private_key_pem()
+    vapid_private_key = _get_vapid_private_key_base64url()
     vapid_claims = _get_vapid_claims()
 
     payload = json.dumps({
@@ -268,7 +268,7 @@ async def send_web_push(
             webpush(
                 subscription_info=subscription_info,
                 data=payload,
-                vapid_private_key=vapid_private_key_pem,
+                vapid_private_key=vapid_private_key,
                 vapid_claims=vapid_claims,
             )
         except WebPushException as e:

--- a/backend/tests/test_push.py
+++ b/backend/tests/test_push.py
@@ -308,6 +308,72 @@ async def test_send_web_push_calls_webpush(db, test_user):
 
 
 
+def test_vapid_private_key_base64url_format():
+    """秘密鍵は base64url(raw 32 バイト) で取得される (PEM ではない)。"""
+    import base64
+
+    from app.services.push_service import _get_vapid_private_key_base64url
+
+    key = _get_vapid_private_key_base64url()
+
+    # PEM ヘッダが混ざっていないこと
+    assert "-----" not in key
+    assert "BEGIN" not in key
+
+    # padding なし base64url が 32 バイトをエンコードした場合は 43 文字
+    assert len(key) == 43, key
+
+    # base64url として decode 可能で、結果が 32 バイトであること
+    decoded = base64.urlsafe_b64decode(key + "==")
+    assert len(decoded) == 32
+
+
+def test_vapid_private_key_loadable_by_pywebpush():
+    """送り出す秘密鍵が py_vapid.Vapid.from_string() で例外なく読める。
+
+    これまで PEM 文字列を渡しており、py_vapid 内で base64url decode → DER parse に
+    落ちて ASN.1 error になっていた (#1056)。本テストは送出経路の鍵フォーマットを
+    end-to-end で検証する回帰防止。
+    """
+    from py_vapid import Vapid
+
+    from app.services.push_service import _get_vapid_private_key_base64url
+
+    key = _get_vapid_private_key_base64url()
+    # 例外が出ないことが期待値。出るならフォーマット側のリグレッション。
+    Vapid.from_string(private_key=key)
+
+
+async def test_send_web_push_passes_base64url_key_to_webpush(db, test_user):
+    """webpush() に渡される vapid_private_key が base64url 文字列 (PEM ではない)。"""
+    from app.services.push_service import create_subscription, send_web_push
+
+    await create_subscription(
+        db,
+        actor_id=test_user.actor_id,
+        session_id="sess-key-fmt",
+        endpoint="https://push.example.com/keyfmt",
+        key_p256dh="key",
+        key_auth="auth",
+    )
+    await db.commit()
+
+    with (
+        patch("pywebpush.webpush") as mock_wp,
+        patch("app.services.push_service.is_push_enabled", return_value=True),
+    ):
+        await send_web_push(
+            db,
+            recipient_id=test_user.actor_id,
+            notification_type="follow",
+            sender_display_name="Alice",
+        )
+
+    passed_key = mock_wp.call_args[1]["vapid_private_key"]
+    assert "-----" not in passed_key
+    assert len(passed_key) == 43
+
+
 async def test_send_web_push_removes_stale_410(db, test_user):
     """410 Gone should trigger automatic subscription removal."""
     from pywebpush import WebPushException


### PR DESCRIPTION
## Summary

- **全 endpoint で Web Push 送信が失敗していた本丸バグの修正**
- `send_web_push()` が VAPID 秘密鍵を PEM 文字列で `pywebpush.webpush()` に渡しており、`py_vapid.Vapid.from_string()` 内の DER フォールバックが ASN.1 parse error で落ちていた
- PEM 用ヘルパー `_get_vapid_private_key_pem()` を base64url 用 `_get_vapid_private_key_base64url()` に置き換える
- Plan: #1056

## 発覚経緯

iPhone PWA で通知が届かないという報告から PR #1055 (49b2609) でログ強化したところ、`Web Push unexpected error: host=web.push.apple.com error=Could not deserialize key data. ... ASN.1 parsing error: invalid length` という具体的な例外が観測できた。Apple 固有の問題ではなく、**Apple/Mozilla/FCM すべてで通知が失敗していた**。

## 原因

```python
# 旧: PEM 文字列を渡していた
vapid_private_key_pem = _get_vapid_private_key_pem()  # "-----BEGIN PRIVATE KEY-----\n..."
webpush(..., vapid_private_key=vapid_private_key_pem, ...)
```

`pywebpush` (`py_vapid`) の鍵パース:

```python
def from_string(cls, private_key):
    pkey = private_key.encode().replace(b"\n", b"")
    key = b64urldecode(pkey)
    if len(key) == 32:
        return cls.from_raw(pkey)   # 正常系: base64url(raw 32 bytes)
    return cls.from_der(pkey)       # フォールバック: DER
```

PEM 文字列を渡すとヘッダごと base64url decode → 32 バイトにならず `from_der` に落ちて ASN.1 error。

## 修正

```python
def _get_vapid_private_key_base64url() -> str:
    raw = _get_vapid_private_key_bytes()  # 既存・raw 32 bytes
    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()

# send_web_push
webpush(..., vapid_private_key=_get_vapid_private_key_base64url(), ...)
```

`_get_vapid_private_key_pem()` は唯一の呼び出し元が消えるため削除。

## Test plan

- [x] `test_vapid_private_key_base64url_format`: PEM ヘッダを含まず、43 文字 (padding なし base64url で 32 バイト)
- [x] `test_vapid_private_key_loadable_by_pywebpush`: 実際に `py_vapid.Vapid.from_string()` に通して例外が出ない (e2e フォーマット契約の回帰防止)
- [x] `test_send_web_push_passes_base64url_key_to_webpush`: `webpush()` 呼び出しの `vapid_private_key` kwarg が PEM ではなく 43 文字 base64url
- [ ] CI 全 18 job pass
- [ ] nekonaudit のレビュー確認
- [ ] マージ後の本番環境で実際に通知が届くこと (iPhone PWA / PC ブラウザ両方)

## 影響範囲

- 既存購読 (`push_subscriptions` テーブル) はそのまま使える
- VAPID 公開鍵 (`get_vapid_public_key_base64url`) は同じ秘密鍵から導出しており不変、**クライアント側の再購読は不要**
- 失敗していた既存通知は遡って配信されない (通知ストリームの取りこぼし扱い)

🤖 Generated with [Claude Code](https://claude.com/claude-code)