### PR TITLE
chore: リリース 20260530-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [20260530-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260530-1) — 2026-05-30
+
+### バグ修正
+
+- **Web Push 通知が全 endpoint で失敗していた問題を修正** — `pywebpush.webpush()` の `vapid_private_key` 引数に PEM 文字列を渡していたため、`py_vapid.Vapid.from_string()` が base64url decode → 32 バイト判定で DER フォールバックに落ち、PEM 由来のバイト列を DER として parse して `ASN.1 parsing error: invalid length` で例外を出していた。base64url(raw 32 バイト) を渡すように修正。Apple/Mozilla/FCM 含むすべての endpoint で通知が送信可能になる。既存購読はそのまま使え、クライアント側の再購読は不要 (#1056, #1057)
+- **Web Push 失敗時のログ強化** — `WebPushException` 発生時にプッシュサービス応答の `status_code` と本文先頭 500 文字を WARNING ログに記録 (Apple は具体的拒否理由を本文で返す)。endpoint は `host` のみ出力し、path に含まれる push token は漏らさない。pywebpush 外の予期せぬ例外でも `exc_info=True` でスタックトレースを残す。上記 PEM バグはこの観測強化で発覚した (#1054, #1055)
+
+### ドキュメント
+
+- **連合テスト手順を `run --build --rm test-runner` に修正** — Misskey/Mastodon/Mitra/Pleroma/Fedibird の連合テストを連続実行すると、test-runner イメージ (`nekonoverse-test-runner:latest`) が variant 間で再利用されて 2 個目以降が必ず失敗する問題があった。compose project 名が共通で image tag が衝突し、`down -v` でもイメージが残るのが原因。`run` に `--build` を付けて毎回再ビルドさせることで回避。CLAUDE.md (submodule) の PR レビュー手順も Devin Review → nekonaudit 表記に更新 (#1052, #1053)
+
+---
+
 ## [20260524-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260524-1) — 2026-05-24
 
 ### CI / 運用ドキュメント

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260524-1"
+__version__ = "20260530-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260524-1"
+version = "20260530-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "nekonoverse"
-version = "20260524.post1"
+version = "20260530.post1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260524-1",
+  "version": "20260530-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260524-1",
+      "version": "20260530-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260524-1",
+  "version": "20260530-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

20260530-1 リリース準備。CHANGELOG とバージョン番号 5 箇所 (`backend/app/__init__.py`, `backend/pyproject.toml`, `backend/uv.lock`, `frontend/package.json`, `frontend/package-lock.json`) を更新。

## 含まれる変更

### バグ修正

- **#1056 / #1057**: VAPID 秘密鍵を base64url(raw 32 バイト) で pywebpush に渡す — Web Push が全 endpoint (Apple/Mozilla/FCM) で `ASN.1 parsing error` により失敗していた本丸バグの修正。既存購読は無効化されず、クライアント側の再購読は不要。
- **#1054 / #1055**: Web Push 失敗時の応答本文ロギング — `WebPushException` 時にプッシュサービス応答の `status_code` と本文先頭 500 文字を WARNING ログに記録。endpoint は host のみログ出力。**この観測強化が PEM バグの発覚を可能にした。**

### ドキュメント

- **#1052 / #1053**: 連合テスト手順を `run --build` に修正 — Misskey/Mastodon/Mitra/Pleroma/Fedibird の連合テストを連続実行すると test-runner イメージが variant 間で再利用されて 2 個目以降が失敗していた問題を、`run --build` への変更で回避。CLAUDE.md (submodule) の PR レビュー手順も Devin Review → nekonaudit に更新。

## 次のステップ

このリリース PR がマージされたら:

1. `develop → main` PR を作成 (GitHub Web UI でマージ)
2. `git tag 20260530-1 && git push origin main --tags`
3. main を develop に merge して同期
4. GitHub Release を作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)