### PR TITLE
chore: リリース 20260602-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [20260602-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260602-1) — 2026-06-02
+
+### セキュリティ
+
+- **vitest 4.1.0 以上に更新 (GHSA-5xrq-8626-4rwp)** — Vitest UI server が listening 時に任意ファイルの読込/実行が可能な critical 脆弱性の修正。devDependency のみのため runtime 影響なし。`frontend/` を `^4.0.18` → `^4.1.8`、`tests/mastodon-client/` を `^3.0.0` → `^4.1.0` (3.x → 4.x のメジャー更新) に揃え、Dependabot alert #42 / #43 を解消 (#1061, #1062)
+
+---
+
 ## [20260530-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260530-1) — 2026-05-30
 
 ### バグ修正

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260530-1"
+__version__ = "20260602-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260530-1"
+version = "20260602-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "nekonoverse"
-version = "20260530.post1"
+version = "20260602.post1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260530-1",
+  "version": "20260602-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260530-1",
+      "version": "20260602-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260530-1",
+  "version": "20260602-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- バージョン番号を 20260602-1 に更新 (3 ファイル + 2 lockfile)
- CHANGELOG.md に 20260602-1 エントリ追加

## 含まれる変更

- #1061 / #1062 vitest を 4.1.0 以上に更新 (GHSA-5xrq-8626-4rwp) — devDependency のみ

## Test plan

- [ ] CI が全 pass
- [ ] このマージ後、`develop` → `main` のリリース PR を作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)