### PR TITLE
fix: quote 通知の i18n 追加と Mastodon API 互換マッピング

### DIFF
--- a/backend/app/api/mastodon/notifications.py
+++ b/backend/app/api/mastodon/notifications.py
@@ -259,9 +259,9 @@ async def _notification_to_response(
     elif notif.type == "renote":
         notif_type = "reblog"
     elif notif.type == "quote":
-        # quote \u306f Mastodon \u6a19\u6e96\u306b\u306a\u3044\u305f\u3081\u3001\u77e5\u3089\u306a\u3044 type \u3092\u843d\u3068\u3059\u516c\u5f0f/\u30b5\u30fc\u30c9
-        # \u30d1\u30fc\u30c6\u30a3\u30af\u30e9\u30a4\u30a2\u30f3\u30c8\u3068\u306e\u4e92\u63db\u6027\u306e\u305f\u3081 "reblog" \u306b\u5909\u63db (Web Push \u306e
-        # NOTIFICATION_TYPE_TO_ALERT \u3082 "quote" \u2192 "reblog" \u306b\u3057\u3066\u3044\u308b\u306e\u3068\u540c\u3058\u65b9\u91dd)
+        # quote \u306f Mastodon \u6a19\u6e96\u306b\u306a\u3044\u3002
+        # \u4e92\u63db\u6027\u306e\u305f\u3081 "reblog" \u306b\u30de\u30c3\u30d4\u30f3\u30b0
+        # (Web Push \u306e NOTIFICATION_TYPE_TO_ALERT \u3068\u540c\u65b9\u91dd)
         notif_type = "reblog"
 
     return NotificationResponse(

--- a/backend/app/api/mastodon/notifications.py
+++ b/backend/app/api/mastodon/notifications.py
@@ -259,9 +259,9 @@ async def _notification_to_response(
     elif notif.type == "renote":
         notif_type = "reblog"
     elif notif.type == "quote":
-        # quote \u306f Mastodon \u6a19\u6e96\u306b\u306a\u3044\u3002
-        # \u4e92\u63db\u6027\u306e\u305f\u3081 "reblog" \u306b\u30de\u30c3\u30d4\u30f3\u30b0
-        # (Web Push \u306e NOTIFICATION_TYPE_TO_ALERT \u3068\u540c\u65b9\u91dd)
+        # quote は Mastodon 標準にない。
+        # 互換性のため "reblog" にマッピング
+        # (Web Push の NOTIFICATION_TYPE_TO_ALERT と同方針)
         notif_type = "reblog"
 
     return NotificationResponse(

--- a/backend/app/api/mastodon/notifications.py
+++ b/backend/app/api/mastodon/notifications.py
@@ -258,6 +258,11 @@ async def _notification_to_response(
         notif_type = "favourite"
     elif notif.type == "renote":
         notif_type = "reblog"
+    elif notif.type == "quote":
+        # quote \u306f Mastodon \u6a19\u6e96\u306b\u306a\u3044\u305f\u3081\u3001\u77e5\u3089\u306a\u3044 type \u3092\u843d\u3068\u3059\u516c\u5f0f/\u30b5\u30fc\u30c9
+        # \u30d1\u30fc\u30c6\u30a3\u30af\u30e9\u30a4\u30a2\u30f3\u30c8\u3068\u306e\u4e92\u63db\u6027\u306e\u305f\u3081 "reblog" \u306b\u5909\u63db (Web Push \u306e
+        # NOTIFICATION_TYPE_TO_ALERT \u3082 "quote" \u2192 "reblog" \u306b\u3057\u3066\u3044\u308b\u306e\u3068\u540c\u3058\u65b9\u91dd)
+        notif_type = "reblog"
 
     return NotificationResponse(
         id=notif.id,

--- a/frontend/src/pages/Notifications.tsx
+++ b/frontend/src/pages/Notifications.tsx
@@ -224,6 +224,7 @@ export default function Notifications() {
       case "reblog": return "\u{1F501}";
       case "favourite": return "\u2B50";
       case "reaction": return "\u2728";
+      case "quote": return "\u{1F4AD}";
       default: return "\u{1F514}";
     }
   };

--- a/packages/ui/src/i18n/dictionaries/en.ts
+++ b/packages/ui/src/i18n/dictionaries/en.ts
@@ -268,6 +268,7 @@ export const en: Dictionary = {
   "notifications.type.favourite": "favorited your post",
   "notifications.type.reaction": "reacted to your post",
   "notifications.type.reply": "replied to your post",
+  "notifications.type.quote": "quoted your post",
   "notifications.tabMentions": "Mentions",
   "notifications.tabOther": "Other",
   "mentions.title": "Mentions",

--- a/packages/ui/src/i18n/dictionaries/ja.ts
+++ b/packages/ui/src/i18n/dictionaries/ja.ts
@@ -266,6 +266,7 @@ export const ja = {
   "notifications.type.favourite": "にお気に入りされました",
   "notifications.type.reaction": "がリアクションしました",
   "notifications.type.reply": "に返信されました",
+  "notifications.type.quote": "に引用されました",
   "notifications.tabMentions": "メンション",
   "notifications.tabOther": "その他",
   "mentions.title": "メンション",

--- a/packages/ui/src/i18n/dictionaries/neko.ts
+++ b/packages/ui/src/i18n/dictionaries/neko.ts
@@ -268,6 +268,7 @@ export const neko: Dictionary = {
   "notifications.type.favourite": "におきにいりされたにゃ",
   "notifications.type.reaction": "がりあくしょんしたにゃ",
   "notifications.type.reply": "にへんしんされたにゃ",
+  "notifications.type.quote": "にいんようされたにゃ",
   "notifications.tabMentions": "めんしょんにゃ",
   "notifications.tabOther": "そのたにゃ",
   "mentions.title": "めんしょんにゃ",


### PR DESCRIPTION
## Summary

#1066 で新しい notification type \`quote\` を導入したが、以下の追従が漏れていたので潰す。リリース 20260602-2 (#1068) 前の修正。

## 変更点

- **packages/ui/src/i18n/dictionaries/{ja,en,neko}.ts** — \`notifications.type.quote\` を追加 (引用通知の本文ラベルが空になっていた)
- **frontend/src/pages/Notifications.tsx** — \`notifIcon\` switch に \`case "quote": return "💭"\` を追加 (引用通知だけアイコンがベルだった)
- **backend/app/api/mastodon/notifications.py** — \`quote → reblog\` の type マッピングを追加。Mastodon 標準にない type を落とす公式/サードパーティクライアントとの互換性確保。Web Push の \`NOTIFICATION_TYPE_TO_ALERT\` も \`quote → reblog\` にしているのと同じ方針

## 背景

nekonaudit (#1068) が指摘:

> packages/ui/src/i18n/dictionaries/{ja,en,neko}.ts — notifications.type.quote キーが全 3 辞書に存在しないが、note_service.py:300-315 と activitypub/handlers/create.py:399-415 で type="quote" の Notification が新規発行される

> backend/app/api/mastodon/notifications.py:254-260 — reaction → favourite, renote → reblog のような Mastodon 互換マッピングが既存。新たに発生する quote タイプはそのまま "quote" として返されるが Mastodon 標準にはない値で、知らない type を受け取った公式/サードパーティクライアントは通知行を落とす実装が多い

## Test plan

- [ ] CI 全 pass
- [ ] マージ後リリース PR #1068 を再 CI / nekonaudit 確認してマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)