### PR TITLE
refactor: Discord Webhook 管理画面のマークアップを既存スタイル規約に揃える

### DIFF
--- a/frontend/src/components/settings/DiscordWebhooksManager.tsx
+++ b/frontend/src/components/settings/DiscordWebhooksManager.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createResource, For, Show } from "solid-js";
+import { createResource, createSignal, For, Show } from "solid-js";
 import { useI18n } from "@nekonoverse/ui/i18n";
 import {
   createDiscordWebhook,
@@ -58,16 +58,21 @@ export default function DiscordWebhooksManager() {
   const { t } = useI18n();
   const [webhooks, { refetch }] = createResource<DiscordWebhook[]>(listDiscordWebhooks);
   const [editing, setEditing] = createSignal<DiscordWebhook | null>(null);
-  const [showCreate, setShowCreate] = createSignal(false);
+  const [showModal, setShowModal] = createSignal(false);
   const [draft, setDraft] = createSignal<DiscordWebhookInput>(defaultInput());
-  const [error, setError] = createSignal<string | null>(null);
-  const [testResult, setTestResult] = createSignal<{ id: string; ok: boolean; message: string } | null>(null);
+  const [error, setError] = createSignal("");
+  const [submitting, setSubmitting] = createSignal(false);
+  const [testResult, setTestResult] = createSignal<{
+    id: string;
+    ok: boolean;
+    message: string;
+  } | null>(null);
 
   function openCreate() {
     setDraft(defaultInput());
     setEditing(null);
-    setError(null);
-    setShowCreate(true);
+    setError("");
+    setShowModal(true);
   }
 
   function openEdit(webhook: DiscordWebhook) {
@@ -84,26 +89,27 @@ export default function DiscordWebhooksManager() {
       enabled: webhook.enabled,
     });
     setEditing(webhook);
-    setError(null);
-    setShowCreate(true);
+    setError("");
+    setShowModal(true);
   }
 
   function closeModal() {
-    setShowCreate(false);
+    setShowModal(false);
     setEditing(null);
-    setError(null);
+    setError("");
   }
 
   async function handleSubmit(e: Event) {
     e.preventDefault();
-    setError(null);
-    const current = editing();
-    const payload = draft();
+    setError("");
+    setSubmitting(true);
     try {
+      const current = editing();
+      const payload = draft();
       if (current) {
-        // 編集モード: webhook_url が空欄なら URL は変更しない
         const updates: Partial<DiscordWebhookInput> = { ...payload };
         if (!payload.webhook_url) {
+          // 編集モードで URL を空欄のまま送らない
           delete updates.webhook_url;
         }
         await updateDiscordWebhook(current.id, updates);
@@ -114,6 +120,8 @@ export default function DiscordWebhooksManager() {
       closeModal();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -151,151 +159,185 @@ export default function DiscordWebhooksManager() {
   return (
     <div class="settings-section">
       <h3>{t("settings.discordWebhooks.title" as any)}</h3>
-      <p class="settings-description">{t("settings.discordWebhooks.description" as any)}</p>
+      <p class="settings-label">{t("settings.discordWebhooks.description" as any)}</p>
+
+      <Show when={error()}>
+        <p class="error">{error()}</p>
+      </Show>
+
+      <Show when={!webhooks.loading} fallback={<p>{t("common.loading")}</p>}>
+        <Show
+          when={(webhooks() ?? []).length > 0}
+          fallback={
+            <p class="webhook-empty">{t("settings.discordWebhooks.empty" as any)}</p>
+          }
+        >
+          <ul class="webhook-list">
+            <For each={webhooks()}>
+              {(webhook) => (
+                <li class="webhook-item">
+                  <div class="webhook-info">
+                    <div class="webhook-name">
+                      <span>{webhook.name}</span>
+                      <Show when={!webhook.enabled}>
+                        <span class="webhook-badge webhook-badge-warn">
+                          {t("settings.discordWebhooks.disabled" as any)}
+                        </span>
+                      </Show>
+                    </div>
+                    <div class="webhook-url">{webhook.webhook_url_masked}</div>
+                    <Show when={webhook.last_error}>
+                      <div class="webhook-error-message">
+                        {t("settings.discordWebhooks.lastError" as any)}:{" "}
+                        {webhook.last_error}
+                      </div>
+                    </Show>
+                    <Show when={testResult() && testResult()!.id === webhook.id}>
+                      <div
+                        class={
+                          testResult()!.ok
+                            ? "webhook-test-success"
+                            : "webhook-test-failure"
+                        }
+                      >
+                        {testResult()!.message}
+                      </div>
+                    </Show>
+                  </div>
+                  <div class="webhook-actions">
+                    <button
+                      class="btn btn-small btn-secondary"
+                      onClick={() => handleTest(webhook)}
+                    >
+                      {t("settings.discordWebhooks.test" as any)}
+                    </button>
+                    <button
+                      class="btn btn-small btn-secondary"
+                      onClick={() => openEdit(webhook)}
+                    >
+                      {t("settings.discordWebhooks.edit" as any)}
+                    </button>
+                    <button
+                      class="btn btn-small btn-danger"
+                      onClick={() => handleDelete(webhook)}
+                    >
+                      {t("settings.discordWebhooks.delete" as any)}
+                    </button>
+                  </div>
+                </li>
+              )}
+            </For>
+          </ul>
+        </Show>
+      </Show>
 
       <button class="btn" onClick={openCreate}>
         {t("settings.discordWebhooks.add" as any)}
       </button>
 
-      <Show when={error()}>
-        <p class="error-message">{error()}</p>
-      </Show>
-
-      <Show
-        when={webhooks() && webhooks()!.length > 0}
-        fallback={
-          <Show when={!webhooks.loading}>
-            <p class="settings-empty">{t("settings.discordWebhooks.empty" as any)}</p>
-          </Show>
-        }
-      >
-        <ul class="discord-webhook-list">
-          <For each={webhooks()!}>
-            {(webhook) => (
-              <li class="discord-webhook-row">
-                <div class="discord-webhook-row-main">
-                  <div class="discord-webhook-row-name">
-                    {webhook.name}
-                    <Show when={!webhook.enabled}>
-                      {" "}
-                      <span class="badge badge-warn">
-                        {t("settings.discordWebhooks.disabled" as any)}
-                      </span>
-                    </Show>
-                  </div>
-                  <div class="discord-webhook-row-url">{webhook.webhook_url_masked}</div>
-                  <Show when={webhook.last_error}>
-                    <div class="discord-webhook-row-error">
-                      {t("settings.discordWebhooks.lastError" as any)}: {webhook.last_error}
-                    </div>
-                  </Show>
-                  <Show when={testResult() && testResult()!.id === webhook.id}>
-                    <div
-                      class={
-                        testResult()!.ok
-                          ? "discord-webhook-row-success"
-                          : "discord-webhook-row-error"
-                      }
-                    >
-                      {testResult()!.message}
-                    </div>
-                  </Show>
-                </div>
-                <div class="discord-webhook-row-actions">
-                  <button class="btn btn-small" onClick={() => handleTest(webhook)}>
-                    {t("settings.discordWebhooks.test" as any)}
-                  </button>
-                  <button class="btn btn-small" onClick={() => openEdit(webhook)}>
-                    {t("settings.discordWebhooks.edit" as any)}
-                  </button>
-                  <button
-                    class="btn btn-small btn-danger"
-                    onClick={() => handleDelete(webhook)}
-                  >
-                    {t("settings.discordWebhooks.delete" as any)}
-                  </button>
-                </div>
-              </li>
-            )}
-          </For>
-        </ul>
-      </Show>
-
-      <Show when={showCreate()}>
+      <Show when={showModal()}>
         <div class="modal-overlay" onClick={closeModal}>
-          <div class="modal-content" onClick={(e) => e.stopPropagation()}>
-            <h4>
-              {editing()
-                ? t("settings.discordWebhooks.editTitle" as any)
-                : t("settings.discordWebhooks.addTitle" as any)}
-            </h4>
-            <form onSubmit={handleSubmit}>
-              <label>
-                {t("settings.discordWebhooks.name" as any)}
-                <input
-                  type="text"
-                  value={draft().name}
-                  onInput={(e) =>
-                    setDraft({ ...draft(), name: e.currentTarget.value })
-                  }
-                  required
-                  maxLength={100}
-                />
-              </label>
-              <label>
-                {t("settings.discordWebhooks.url" as any)}
-                <input
-                  type="url"
-                  value={draft().webhook_url}
-                  onInput={(e) =>
-                    setDraft({ ...draft(), webhook_url: e.currentTarget.value })
-                  }
-                  placeholder={t("settings.discordWebhooks.urlPlaceholder" as any)}
-                  required={!editing()}
-                />
-                <Show when={editing()}>
-                  <small>{t("settings.discordWebhooks.urlEditHint" as any)}</small>
+          <div
+            class="modal-content"
+            style={{ "max-width": "520px" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div class="modal-header">
+              <h3>
+                {editing()
+                  ? t("settings.discordWebhooks.editTitle" as any)
+                  : t("settings.discordWebhooks.addTitle" as any)}
+              </h3>
+              <button class="modal-close" onClick={closeModal} aria-label="close">
+                ✕
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} class="webhook-form">
+              <div class="webhook-form-body">
+                <div class="settings-form-group">
+                  <label>{t("settings.discordWebhooks.name" as any)}</label>
+                  <input
+                    type="text"
+                    value={draft().name}
+                    onInput={(e) =>
+                      setDraft({ ...draft(), name: e.currentTarget.value })
+                    }
+                    required
+                    maxLength={100}
+                  />
+                </div>
+
+                <div class="settings-form-group">
+                  <label>{t("settings.discordWebhooks.url" as any)}</label>
+                  <input
+                    type="url"
+                    value={draft().webhook_url}
+                    onInput={(e) =>
+                      setDraft({ ...draft(), webhook_url: e.currentTarget.value })
+                    }
+                    placeholder={t("settings.discordWebhooks.urlPlaceholder" as any)}
+                    required={!editing()}
+                  />
+                  <Show when={editing()}>
+                    <small class="settings-label">
+                      {t("settings.discordWebhooks.urlEditHint" as any)}
+                    </small>
+                  </Show>
+                </div>
+
+                <div class="settings-form-group">
+                  <label>{t("settings.discordWebhooks.notifyTitle" as any)}</label>
+                  <div class="webhook-notify-grid">
+                    <For each={NOTIFY_KEYS}>
+                      {(key) => (
+                        <label class="toggle-label">
+                          <input
+                            type="checkbox"
+                            checked={draft()[key] ?? true}
+                            onChange={(e) =>
+                              setDraft({
+                                ...draft(),
+                                [key]: e.currentTarget.checked,
+                              })
+                            }
+                          />
+                          <span>{t(NOTIFY_LABEL_KEY[key] as any)}</span>
+                        </label>
+                      )}
+                    </For>
+                  </div>
+                </div>
+
+                <label class="toggle-label">
+                  <input
+                    type="checkbox"
+                    checked={draft().enabled ?? true}
+                    onChange={(e) =>
+                      setDraft({ ...draft(), enabled: e.currentTarget.checked })
+                    }
+                  />
+                  <span>{t("settings.discordWebhooks.enabled" as any)}</span>
+                </label>
+
+                <Show when={error()}>
+                  <p class="error">{error()}</p>
                 </Show>
-              </label>
+              </div>
 
-              <fieldset>
-                <legend>{t("settings.discordWebhooks.notifyTitle" as any)}</legend>
-                <For each={NOTIFY_KEYS}>
-                  {(key) => (
-                    <label class="checkbox-label">
-                      <input
-                        type="checkbox"
-                        checked={draft()[key] ?? true}
-                        onChange={(e) =>
-                          setDraft({ ...draft(), [key]: e.currentTarget.checked })
-                        }
-                      />
-                      {t(NOTIFY_LABEL_KEY[key] as any)}
-                    </label>
-                  )}
-                </For>
-              </fieldset>
-
-              <label class="checkbox-label">
-                <input
-                  type="checkbox"
-                  checked={draft().enabled ?? true}
-                  onChange={(e) =>
-                    setDraft({ ...draft(), enabled: e.currentTarget.checked })
-                  }
-                />
-                {t("settings.discordWebhooks.enabled" as any)}
-              </label>
-
-              <Show when={error()}>
-                <p class="error-message">{error()}</p>
-              </Show>
-
-              <div class="modal-actions">
-                <button type="button" class="btn" onClick={closeModal}>
+              <div class="modal-footer">
+                <button
+                  type="button"
+                  class="btn btn-small btn-secondary"
+                  onClick={closeModal}
+                >
                   {t("common.cancel" as any)}
                 </button>
-                <button type="submit" class="btn btn-primary">
+                <button
+                  type="submit"
+                  class="btn btn-small"
+                  disabled={submitting()}
+                >
                   {t("common.save" as any)}
                 </button>
               </div>

--- a/frontend/src/components/settings/DiscordWebhooksManager.tsx
+++ b/frontend/src/components/settings/DiscordWebhooksManager.tsx
@@ -252,7 +252,7 @@ export default function DiscordWebhooksManager() {
               <button
                 class="modal-close"
                 onClick={closeModal}
-                aria-label={t("common.close" as any)}
+                aria-label={t("common.close")}
               >
                 ✕
               </button>

--- a/frontend/src/components/settings/DiscordWebhooksManager.tsx
+++ b/frontend/src/components/settings/DiscordWebhooksManager.tsx
@@ -76,6 +76,7 @@ export default function DiscordWebhooksManager() {
   }
 
   function openEdit(webhook: DiscordWebhook) {
+    setTestResult(null);
     setDraft({
       name: webhook.name,
       webhook_url: "",
@@ -127,6 +128,7 @@ export default function DiscordWebhooksManager() {
 
   async function handleDelete(webhook: DiscordWebhook) {
     if (!confirm(t("settings.discordWebhooks.deleteConfirm" as any))) return;
+    setTestResult(null);
     try {
       await deleteDiscordWebhook(webhook.id);
       await refetch();
@@ -238,8 +240,7 @@ export default function DiscordWebhooksManager() {
       <Show when={showModal()}>
         <div class="modal-overlay" onClick={closeModal}>
           <div
-            class="modal-content"
-            style={{ "max-width": "520px" }}
+            class="modal-content webhook-modal"
             onClick={(e) => e.stopPropagation()}
           >
             <div class="modal-header">
@@ -248,7 +249,11 @@ export default function DiscordWebhooksManager() {
                   ? t("settings.discordWebhooks.editTitle" as any)
                   : t("settings.discordWebhooks.addTitle" as any)}
               </h3>
-              <button class="modal-close" onClick={closeModal} aria-label="close">
+              <button
+                class="modal-close"
+                onClick={closeModal}
+                aria-label={t("common.close" as any)}
+              >
                 ✕
               </button>
             </div>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -3907,7 +3907,12 @@ a:hover {
 }
 
 /* Discord webhook modal form */
-.webhook-modal {
+/*
+  .modal-content (max-width:560px) と同詳細度の単独セレクタだと
+  ファイル後方に出てくる .modal-content が後勝ちで負ける。
+  詳細度を 1 段上げて確実に効かせる。
+*/
+.modal-content.webhook-modal {
   max-width: 520px;
 }
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -3900,12 +3900,17 @@ a:hover {
 
 .webhook-actions {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 6px;
   flex-shrink: 0;
+  align-self: flex-start;
 }
 
 /* Discord webhook modal form */
+.webhook-modal {
+  max-width: 520px;
+}
+
 .webhook-form {
   display: flex;
   flex-direction: column;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -3809,6 +3809,129 @@ a:hover {
   background: rgba(233, 69, 96, 0.15);
 }
 
+/* Discord webhook manager (settings) */
+.webhook-empty {
+  color: var(--text-secondary);
+  font-size: 0.875em;
+  margin: 12px 0 16px;
+}
+
+.webhook-list {
+  list-style: none;
+  margin: 12px 0 16px;
+  padding: 0;
+}
+
+.webhook-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.webhook-item:last-child {
+  border-bottom: none;
+}
+
+.webhook-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+
+.webhook-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1em;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.webhook-url {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.8em;
+  color: var(--text-secondary);
+  word-break: break-all;
+}
+
+.webhook-badge {
+  display: inline-block;
+  font-size: 0.7em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 500;
+}
+
+.webhook-badge-warn {
+  background: rgba(241, 196, 15, 0.15);
+  color: #f1c40f;
+}
+
+.webhook-error-message {
+  background: rgba(233, 69, 96, 0.12);
+  color: #e94560;
+  padding: 6px 10px;
+  border-radius: var(--radius);
+  font-size: 0.8em;
+  word-break: break-word;
+}
+
+.webhook-test-success {
+  background: rgba(46, 204, 113, 0.15);
+  color: #2ecc71;
+  padding: 6px 10px;
+  border-radius: var(--radius);
+  font-size: 0.8em;
+}
+
+.webhook-test-failure {
+  background: rgba(233, 69, 96, 0.12);
+  color: #e94560;
+  padding: 6px 10px;
+  border-radius: var(--radius);
+  font-size: 0.8em;
+  word-break: break-word;
+}
+
+.webhook-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* Discord webhook modal form */
+.webhook-form {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+.webhook-form-body {
+  padding: 16px 18px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.webhook-notify-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 4px 12px;
+  margin-top: 4px;
+}
+
+.webhook-notify-grid .toggle-label {
+  margin-top: 0;
+}
+
 /* Passkey login divider */
 .passkey-divider {
   display: flex;


### PR DESCRIPTION
## Summary

#1066 で導入した `DiscordWebhooksManager` と Webhook 追加・編集モーダルが、グローバル CSS に存在しないクラス (`.discord-webhook-list` / `.modal-actions` / `.checkbox-label` / `.badge-warn` / `.settings-empty` 等) を多用していて視覚的に未完成だったので、既存パターンに合わせて整理する。

## 何を直したか

### 一覧マネージャ

- 構造を `.passkey-list` / `.passkey-item` パターンに揃える
  - `.webhook-list` (ul)
  - `.webhook-item` (li, flex row, border-bottom)
  - `.webhook-info` (左カラム: 名前 / URL / エラー / テスト結果)
  - `.webhook-actions` (右カラム: テスト / 編集 / 削除ボタン)
- 名前行 `.webhook-name` に「無効」状態の `.webhook-badge.webhook-badge-warn` ピル
- URL は `.webhook-url` で monospace + `--text-secondary`
- エラー表示: `.webhook-error-message` (赤系背景)
- テスト送信結果: `.webhook-test-success` (緑) / `.webhook-test-failure` (赤)
- 空状態: `.webhook-empty` (色弱の 1 行)

### モーダル

- 既存 `.modal-overlay` / `.modal-content` / `.modal-header` / `.modal-close` / `.modal-footer` 規約に乗せ替え
- スクロール領域を `.webhook-form-body` に分離 (modal-content の `overflow:hidden` + `max-height:80vh` を尊重)

### フォーム

- `.settings-form-group` + `.toggle-label` で既存の設定タブと統一
- 通知タイプのチェックボックス群は `.webhook-notify-grid` (auto-fill grid) でレスポンシブに 2 列以上
- ボタンは `.btn .btn-small` + `.btn-secondary` / `.btn-danger` で他設定タブと統一

## 変更内容

- `frontend/src/components/settings/DiscordWebhooksManager.tsx` — JSX 構造を全面的にリファクタ (機能は同じ)
- `frontend/src/styles/global.css` — `.webhook-*` クラスを passkey ブロック直後に追加

## Test plan

- [ ] CI 全 pass
- [ ] 開発環境で設定 > Discord Webhook を開き、一覧 / 追加モーダル / 編集モーダル / テスト送信 / 削除確認を一通り確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)