### PR TITLE
fix: markdown DoS 修正版を取り込み PYSEC-2026-89 の ignore を解除 (#1047)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -39,15 +39,10 @@ jobs:
       - run: |
           pip-audit \
             --ignore-vuln CVE-2026-4539 \
-            --ignore-vuln CVE-2026-3219 \
-            --ignore-vuln PYSEC-2026-89
+            --ignore-vuln CVE-2026-3219
           # CVE-2026-4539: pygments 2.19.2, no fix available yet
           # CVE-2026-3219: pip 26.0.1 自身、修正版未リリース。tar+ZIP 連結ファイル誤認識 (CVSS 4.6
           #   MEDIUM、AV:L + UI:A)。CI は信頼できる PyPI/自前依存のみ install するので実質リスクなし
-          # PYSEC-2026-89: markdown >= 3.8 の html.parser.HTMLParser 未捕捉 AssertionError による DoS。
-          #   修正版未リリース。nekonoverse での markdown 利用は admin 専用経路 (利用規約・お知らせ)
-          #   のみで、入力は admin/staff から、出力は bleach.clean サニタイズ。untrusted markdown は
-          #   受け取らないため attack vector が成立しない。upstream fix は #1047 で追跡。
 
   npm-audit:
     name: npm audit (Node.js)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "webauthn>=2.0.0",
     "pyotp>=2.9.0",
     "pywebpush>=2.0.0",
-    "markdown>=3.7",
+    "markdown>=3.8.1",
     "aiosmtplib>=3.0.0",
     "cbor2>=5.9.0",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1086,7 +1086,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.0" },
     { name = "httpx", extras = ["socks"], marker = "extra == 'dev'", specifier = ">=0.28.0" },
-    { name = "markdown", specifier = ">=3.7" },
+    { name = "markdown", specifier = ">=3.8.1" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "psycopg2-binary", marker = "extra == 'dev'", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.10.0" },


### PR DESCRIPTION
## 概要

#1047 対応。PYSEC-2026-89 (Python-Markdown >= 3.8 の `html.parser.HTMLParser` 未捕捉 `AssertionError` による DoS, CVSS HIGH availability) は **markdown 3.8.1 で upstream 修正済み**。

現状 `backend/uv.lock` は既に markdown **3.10.2** (修正版) を解決しているため、PR #1046 (20260520-1) で `--ignore-vuln` 受容していた本脆弱性はもう抑制する必要がない。

## 変更内容

1. `.github/workflows/security-audit.yml` — `pip-audit` の `--ignore-vuln PYSEC-2026-89` と受容理由コメントを削除 (`CVE-2026-4539` / `CVE-2026-3219` は修正版未リリースのため継続)
2. `backend/pyproject.toml` — 将来の再解決でも脆弱版を引かないよう floor を `markdown>=3.7` → `markdown>=3.8.1` (修正版) に引き上げ
3. `backend/uv.lock` — root の requires-dist specifier を `>=3.8.1` に同期 (解決版 3.10.2 は不変)

## 確認

- markdown 解決版は 3.10.2 (>= 修正版 3.8.1) のままで挙動変化なし
- `pip-audit` は ignore なしで markdown を検査するようになるが、3.10.2 に既知脆弱性なし

Closes #1047