### PR TITLE
chore: リリース 20260605-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [20260605-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260605-1) — 2026-06-05
+
+### セキュリティ
+
+- **markdown DoS (PYSEC-2026-89) の修正版を取り込み `--ignore-vuln` を解除** — Python-Markdown >= 3.8 で細工された HTML 系入力により `html.parser.HTMLParser` が未捕捉 `AssertionError` を出す DoS (CVSS HIGH availability) は upstream の markdown 3.8.1 で修正済み。`backend/uv.lock` は既に 3.10.2 (修正版) を解決しているため、20260520-1 で `security-audit.yml` に追加していた `--ignore-vuln PYSEC-2026-89` と受容理由コメントを削除。将来の `uv lock` 再解決でも脆弱版を引かないよう依存宣言の floor を `markdown>=3.7` → `>=3.8.1` に引き上げ、`uv.lock` の specifier も同期した (#1047, #1076)
+
+### 依存関係
+
+- **starlette 0.52.1 → 1.0.1** — Starlette 初の安定版メジャーリリースを取り込み。FastAPI 0.135.1 は `starlette>=0.46.0` を要求しており 1.0.1 と互換、本体に starlette の直接 import は無く backend / E2E / 連合 / Mastodon クライアント互換テストはすべて green。1.0.1 は不正な `Host` ヘッダを無視して `request.url` を構築する fix を含む (#1075)
+- **aiohttp 3.13.5 → 3.14.0** — Dependabot による定期更新。CI green (#1074)
+
+---
+
 ## [20260602-3](https://github.com/nekonoverse/nekonoverse/releases/tag/20260602-3) — 2026-06-02
 
 ### バグ修正

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260602-3"
+__version__ = "20260605-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260602-3"
+version = "20260605-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1033,7 +1033,7 @@ wheels = [
 
 [[package]]
 name = "nekonoverse"
-version = "20260602.post3"
+version = "20260605.post1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260602-3",
+  "version": "20260605-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260602-3",
+      "version": "20260605-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260602-3",
+  "version": "20260605-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## リリース 20260605-1

CHANGELOG とバージョン番号 (backend `__init__.py` / `pyproject.toml` / frontend `package.json`) を `20260605-1` に更新。

### 含まれる変更 (20260602-3 以降)

#### セキュリティ
- markdown DoS (PYSEC-2026-89) の修正版 (3.8.1) 取り込みで `security-audit.yml` の `--ignore-vuln PYSEC-2026-89` を解除、floor を `markdown>=3.8.1` に引き上げ (#1047, #1076)

#### 依存関係
- starlette 0.52.1 → 1.0.1 (#1075)
- aiohttp 3.13.5 → 3.14.0 (#1074)

マージ後、develop→main の Release PR を作成する。