### PR TITLE
chore: リリース 20260608-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [20260605-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260605-1) — 2026-06-05
+## [20260608-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260608-1) — 2026-06-08
 
 ### セキュリティ
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260605-1"
+__version__ = "20260608-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260605-1"
+version = "20260608-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1033,7 +1033,7 @@ wheels = [
 
 [[package]]
 name = "nekonoverse"
-version = "20260605.post1"
+version = "20260608.post1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260605-1",
+  "version": "20260608-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260605-1",
+      "version": "20260608-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260605-1",
+  "version": "20260608-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## リリース 20260608-1

#1078 (Release 20260605-1) が未マージのまま close されたため、同一内容を本日の日付で出し直す。CHANGELOG とバージョン番号 (`backend/app/__init__.py` / `backend/pyproject.toml` / `frontend/package.json` / `backend/uv.lock` self-version / `frontend/package-lock.json`) を `20260608-1` に揃える。リリース内容は 20260605-1 と同一:

### セキュリティ
- **markdown DoS (PYSEC-2026-89) の修正版を取り込み `--ignore-vuln` を解除** — upstream の markdown 3.8.1 で修正済み (lock は 3.10.2 を解決)。`security-audit.yml` の `--ignore-vuln PYSEC-2026-89` を削除し、floor を `markdown>=3.8.1` に引き上げ (#1047, #1076)

### 依存関係
- **starlette 0.52.1 → 1.0.1** — FastAPI 0.135.1 (`starlette>=0.46.0`) と互換、直接 import なし (#1075)
- **aiohttp 3.13.5 → 3.14.0** (#1074)

このPRを develop にマージ後、develop → main のリリース PR を別途作成する。