### PR TITLE
fix: dompurify を 3.4.10 に更新 (XSS advisory 解消)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.10",
         "katex": "^0.16.40",
         "mfm-js": "^0.25.0",
         "qrcode": "^1.5.4",
@@ -3776,9 +3776,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@solid-primitives/i18n": "^2.1.1",
     "@solidjs/router": "^0.15.0",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.10",
     "katex": "^0.16.40",
     "mfm-js": "^0.25.0",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
## 概要

リモート HTML サニタイズに用いる **runtime dependency** の `dompurify` を `^3.4.0` → `^3.4.10` に更新し、`npm audit --omit=dev` で検出される IN_PLACE 系 XSS advisory 群(`GHSA-x4vx-rjvf-j5p4` ほか)を解消する。

- 利用箇所は `frontend/src/pages/Terms.tsx` / `Privacy.tsx` の2か所で、いずれも `ALLOWED_TAGS`/`ALLOWED_ATTR` 明示呼び出し。patch 級更新で挙動互換。
- develop に既存の検出で、`npm audit (Node.js)` CI もこれでブロックされていた。

## 変更

- `frontend/package.json`: `dompurify` `^3.4.0` → `^3.4.10`
- `frontend/package-lock.json`: dompurify のみ更新(最小差分)

## 検証(node:22 コンテナ・CI 同等手順)

- `npm ci` ✓
- `npm audit --omit=dev` → **0 vulnerabilities** ✓
- `npx vitest run` → **207 passed** ✓
- `npm run build` ✓ / `vite dev` サーバ配信 ✓(root HTML・TSX 変換・dep 最適化すべて 200)

## 備考: esbuild #47 (GHSA-gv7w-rqvm-qjhr) について

当初 esbuild の override 更新も含めていたが、**vite 6 の dev サーバが esbuild 0.28 と非互換**(optimizeDeps が「destructuring を target 環境へ変換できない」で 121 エラー → e2e 全シャードがフロント起動失敗で 15 分タイムアウト)のため取り下げた。vite 7 は esbuild `^0.27`(まだ脆弱)、esbuild を廃するのは vite 8 のみだが vite-plugin-solid 非互換でビルドが落ちる。esbuild #47 は devDependency のため別途方針を判断する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)