### PR TITLE
fix: vite を 6.4.3 に更新 (server.fs.deny バイパス等)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "@types/qrcode": "^1.5.6",
         "jsdom": "^28.1.0",
         "typescript": "^5.7.0",
-        "vite": "^6.4.2",
+        "vite": "^6.4.3",
         "vite-plugin-pwa": "^0.21.0",
         "vite-plugin-solid": "^2.11.0",
         "vitest": "^4.1.8"
@@ -6831,9 +6831,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@types/qrcode": "^1.5.6",
     "jsdom": "^28.1.0",
     "typescript": "^5.7.0",
-    "vite": "^6.4.2",
+    "vite": "^6.4.3",
     "vite-plugin-pwa": "^0.21.0",
     "vite-plugin-solid": "^2.11.0",
     "vitest": "^4.1.8"


### PR DESCRIPTION
## 概要

`frontend` の devDependency `vite` を `^6.4.2` → `^6.4.3` に更新し、Dependabot アラート #66 (high) / #67 (medium) を解消する。

| アラート | 重大度 | GHSA | 内容 |
|---------|--------|------|------|
| #66 | high | GHSA-fx2h-pf6j-xcff | `server.fs.deny` bypass on Windows alternate paths |
| #67 | medium | GHSA-v6wh-96g9-6wx3 | (vite dev server) |

patch 級更新で **esbuild は 0.25.12 のまま**(vite 6 の dev サーバ互換を維持。esbuild 0.28 への bump は別件 #47 で確認した通り vite 6 dev を壊すため行わない)。

## 検証(node:22 コンテナ・CI 同等手順)

- `npm ci` ✓(vite 6.4.3)
- `npm audit --omit=dev` → **0 vulnerabilities** ✓
- `npx vitest run` → **207 passed** ✓
- `npm run build` ✓
- `vite dev` サーバ配信 ✓(root HTML・TSX 変換・dep 最適化すべて HTTP 200、optimizeDeps エラーなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)