### PR TITLE
chore: リリース 20260616-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [20260616-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260616-1) — 2026-06-16
+
+### セキュリティ
+
+依存関係のセキュリティ更新リリース。Dependabot アラート群 (high 5 / medium 7 / low 多数) を解消し、ビルドを壊さず修正できない 1 件を受容理由付きで dismiss した。
+
+- **backend ランタイム依存の更新 (high)** — `cryptography` 46.0.7 → 49.0.0 (#56)、`python-multipart` 0.0.27 → 0.0.32 (#62)、`starlette` 1.0.1 → 1.3.1 (#58/#64)。`pyproject.toml` の制約は据え置き `uv lock --upgrade-package` で解決。cryptography は 3 メジャー跨ぐため `app.utils.crypto` / `app.activitypub.http_signature` の RSA/Ed25519 鍵生成・署名スモークに加え、Misskey (56 tests) / Mastodon (37 tests) との federation interop で HTTP Signature 互換を確認 (#1085)
+- **backend ランタイム依存の更新 (medium/low)** — `aiohttp` 3.14.0 → 3.14.1 (#48–#55)、`bleach` 6.3.0 → 6.4.0 (#68/#69/#70)。bleach #69 (GHSA-g75f-g53v-794x, `linkify(parse_email=True)` の CPU 枯渇) は vulnerable range が `=6.3.0` のみで 6.4.0 へ上げて range 外。`sanitize.py` は `bleach.clean` のみ使用し linkify は自前正規表現のため実到達なしの予防的更新 (#1089)
+- **vite 6.4.3 に更新 (server.fs.deny バイパス等)** — Dependabot アラート #66 (high, GHSA-fx2h-pf6j-xcff, Windows 上の `server.fs.deny` バイパス) / #67 (medium) を解消。devDependency、esbuild は 0.25 系に据え置き vite 6 dev サーバ互換を維持 (#1086)
+- **dompurify 3.4.10 に更新 (XSS advisory 解消)** — `npm audit --omit=dev` で検出される IN_PLACE 系 XSS advisory 群 (GHSA-x4vx-rjvf-j5p4 ほか) を解消。利用箇所は Terms.tsx / Privacy.tsx の `ALLOWED_TAGS`/`ALLOWED_ATTR` 明示呼び出しのみで挙動互換 (#1082)
+- **@babel/core 7.29.7 に更新** — Dependabot アラート #65 (low) を解消。transitive devDependency で本番 bundle に @babel ランタイムは含まれない (#1090)
+- **esbuild の Deno 限定 RCE (GHSA-gv7w-rqvm-qjhr) を tolerable_risk で受容** — devDependency かつ Deno 経由インストール限定の脆弱性で、本プロジェクトは npm + Docker (Node.js) でビルドし Deno を使用しないため実エクスポージャなし。esbuild 0.28.1 への更新は vite 6 の dev サーバ optimizeDeps を破壊し (esbuild を廃せるのは vite 8 だが vite-plugin-solid 非互換でビルドが落ちる)、ビルドを壊さず修正する依存経路が存在しないため dismiss (alert #47)
+
+---
+
 ## [20260608-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260608-1) — 2026-06-08
 
 ### セキュリティ

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260608-1"
+__version__ = "20260616-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260608-1"
+version = "20260616-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1030,7 +1030,7 @@ wheels = [
 
 [[package]]
 name = "nekonoverse"
-version = "20260608.post1"
+version = "20260616.post1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosmtplib" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260608-1",
+  "version": "20260616-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260608-1",
+      "version": "20260616-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260608-1",
+  "version": "20260616-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## リリース 20260616-1

依存関係のセキュリティ更新リリース。バージョンを `20260608-1` → `20260616-1` に更新(`backend/app/__init__.py` / `backend/pyproject.toml` / `backend/uv.lock` / `frontend/package.json`)し、CHANGELOG にエントリを追加。

### 含まれる変更(前回リリース以降)
- #1082 dompurify 3.4.10 (XSS)
- #1086 vite 6.4.3 (#66 high / #67 medium)
- #1085 cryptography 49 / python-multipart 0.0.32 / starlette 1.3.1 (high) — Misskey/Mastodon interop で HTTP Signature 互換確認済み
- #1089 aiohttp 3.14.1 / bleach 6.4.0 (medium/low)
- #1090 @babel/core 7.29.7 (low)
- esbuild #47 は tolerable_risk で dismiss、Dependabot PR #1081 はクローズ

機能変更なし。Dependabot アラートは全件クローズ/dismiss 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)