### PR TITLE
fix: frontend 依存のセキュリティ更新 (dompurify 3.4.11 / undici 7.28.0)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",
-        "dompurify": "^3.4.10",
+        "dompurify": "^3.4.11",
         "katex": "^0.16.40",
         "mfm-js": "^0.25.0",
         "qrcode": "^1.5.4",
@@ -3808,9 +3808,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6739,9 +6739,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@solid-primitives/i18n": "^2.1.1",
     "@solidjs/router": "^0.15.0",
-    "dompurify": "^3.4.10",
+    "dompurify": "^3.4.11",
     "katex": "^0.16.40",
     "mfm-js": "^0.25.0",
     "qrcode": "^1.5.4",
@@ -31,6 +31,6 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "picomatch": "^4.0.4",
-    "undici": "^7.24.0"
+    "undici": "^7.28.0"
   }
 }


### PR DESCRIPTION
## 概要

frontend の依存関係に対する Dependabot アラート (1 high / 2 moderate) を解消する。

| パッケージ | scope | 変更 | severity |
|-----------|-------|------|----------|
| dompurify | runtime | 3.4.10 → 3.4.11 | medium |
| undici | dev (overrides 経由 / jsdom 依存) | 7.24.4 → 7.28.0 | high + medium |

- `dompurify` は `dependencies` の直接依存。`^3.4.10` → `^3.4.11`。
- `undici` は `overrides` でピン留めされた jsdom (devDependency) の transitive 依存。`^7.24.0` → `^7.28.0`。
- `--package-lock-only` で更新（node_modules は Docker 管理）。

解消する Dependabot アラート: #71, #72, #73