### PR TITLE
chore: リリース 20260621-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [20260621-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260621-1) — 2026-06-21
+
+### セキュリティ
+
+依存関係のセキュリティ更新リリース。Dependabot アラート 4 件 (high 1 / medium 3) を解消した。いずれもランタイムコードは無変更で、lockfile / 依存宣言の更新のみ。
+
+- **frontend ランタイム依存 `dompurify` を 3.4.11 に更新 (medium)** — `ALLOWED_ATTR` が `setConfig()` 経由で hook clone-guard を回避して恒久汚染される脆弱性 (GHSA-cmwh-pvxp-8882, 3.4.7 の hook 汚染修正の不完全な対応)。利用箇所は Terms.tsx / Privacy.tsx の `ALLOWED_TAGS`/`ALLOWED_ATTR` 明示呼び出しのみで挙動互換。`dependencies` の直接依存を `^3.4.10` → `^3.4.11` (#1095)
+- **frontend devDependency `undici` を 7.28.0 に更新 (high + medium)** — SOCKS5 ProxyAgent で `requestTls` が欠落し TLS 証明書検証がバイパスされる脆弱性 (GHSA-vmh5-mc38-953g, high) と、共有キャッシュの空白バイパスによるクロスユーザー情報漏洩 (GHSA-pr7r-676h-xcf6, medium)。jsdom (devDependency) の transitive 依存で、`overrides` のピンを `^7.24.0` → `^7.28.0` に引き上げて解決。テスト/ビルド専用で本番バンドルには含まれない (#1095)
+- **backend ランタイム依存 `pydantic-settings` を 2.14.2 に更新 (medium)** — `NestedSecretsSettingsSource` が `secrets_dir` 外への symlink を辿り、ローカルファイル読み取りと `secrets_dir_max_size` バイパスを許す脆弱性 (GHSA-4xgf-cpjx-pc3j)。`pyproject.toml` 制約 `>=2.7.0` は満たすため `uv lock --upgrade-package` で当該パッケージのみ更新 (2.13.1 → 2.14.2)、`backend/uv.lock` の差分のみ (#1097)
+
+---
+
 ## [20260616-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260616-1) — 2026-06-16
 
 ### セキュリティ

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260616-1"
+__version__ = "20260621-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260616-1"
+version = "20260621-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260616-1",
+  "version": "20260621-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260616-1",
+      "version": "20260621-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260616-1",
+  "version": "20260621-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 概要

リリース 20260621-1。前回 (20260616-1) 以降の依存セキュリティ更新をまとめる。

### 内容

- CHANGELOG.md に 20260621-1 エントリを追加
- バージョン番号を 20260621-1 に更新 (`backend/app/__init__.py` / `backend/pyproject.toml` / `frontend/package.json` / `frontend/package-lock.json`)

### 含まれる変更 (develop マージ済み)

- frontend 依存: dompurify 3.4.11 / undici 7.28.0 (#1095)
- backend 依存: pydantic-settings 2.14.2 (#1097)

解消した Dependabot アラート: #71 (high), #72, #73, #74 (medium)