### PR TITLE
Release 20260621-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [20260621-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260621-1) — 2026-06-21
+
+### セキュリティ
+
+依存関係のセキュリティ更新リリース。Dependabot アラート 4 件 (high 1 / medium 3) を解消した。いずれもランタイムコードは無変更で、lockfile / 依存宣言の更新のみ。
+
+- **frontend ランタイム依存 `dompurify` を 3.4.11 に更新 (medium)** — `ALLOWED_ATTR` が `setConfig()` 経由で hook clone-guard を回避して恒久汚染される脆弱性 (GHSA-cmwh-pvxp-8882, 3.4.7 の hook 汚染修正の不完全な対応)。利用箇所は Terms.tsx / Privacy.tsx の `ALLOWED_TAGS`/`ALLOWED_ATTR` 明示呼び出しのみで挙動互換。`dependencies` の直接依存を `^3.4.10` → `^3.4.11` (#1095)
+- **frontend devDependency `undici` を 7.28.0 に更新 (high + medium)** — SOCKS5 ProxyAgent で `requestTls` が欠落し TLS 証明書検証がバイパスされる脆弱性 (GHSA-vmh5-mc38-953g, high) と、共有キャッシュの空白バイパスによるクロスユーザー情報漏洩 (GHSA-pr7r-676h-xcf6, medium)。jsdom (devDependency) の transitive 依存で、`overrides` のピンを `^7.24.0` → `^7.28.0` に引き上げて解決。テスト/ビルド専用で本番バンドルには含まれない (#1095)
+- **backend ランタイム依存 `pydantic-settings` を 2.14.2 に更新 (medium)** — `NestedSecretsSettingsSource` が `secrets_dir` 外への symlink を辿り、ローカルファイル読み取りと `secrets_dir_max_size` バイパスを許す脆弱性 (GHSA-4xgf-cpjx-pc3j)。`pyproject.toml` 制約 `>=2.7.0` は満たすため `uv lock --upgrade-package` で当該パッケージのみ更新 (2.13.1 → 2.14.2)、`backend/uv.lock` の差分のみ (#1097)
+
+---
+
 ## [20260616-1](https://github.com/nekonoverse/nekonoverse/releases/tag/20260616-1) — 2026-06-16
 
 ### セキュリティ

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20260616-1"
+__version__ = "20260621-1"
 
 
 def _resolve_version() -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nekonoverse"
-version = "20260616-1"
+version = "20260621-1"
 description = "ActivityPub server with Misskey-compatible emoji reactions"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1434,16 +1434,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260616-1",
+  "version": "20260621-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nekonoverse-frontend",
-      "version": "20260616-1",
+      "version": "20260621-1",
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@solid-primitives/i18n": "^2.1.1",
         "@solidjs/router": "^0.15.0",
-        "dompurify": "^3.4.10",
+        "dompurify": "^3.4.11",
         "katex": "^0.16.40",
         "mfm-js": "^0.25.0",
         "qrcode": "^1.5.4",
@@ -3808,9 +3808,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6739,9 +6739,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@solid-primitives/i18n": "^2.1.1",
     "@solidjs/router": "^0.15.0",
-    "dompurify": "^3.4.10",
+    "dompurify": "^3.4.11",
     "katex": "^0.16.40",
     "mfm-js": "^0.25.0",
     "qrcode": "^1.5.4",
@@ -31,6 +31,6 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "picomatch": "^4.0.4",
-    "undici": "^7.24.0"
+    "undici": "^7.28.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nekonoverse-frontend",
-  "version": "20260616-1",
+  "version": "20260621-1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release 20260621-1

依存セキュリティ更新リリース。Dependabot アラート 4 件 (high 1 / medium 3) を解消。

| パッケージ | 変更 | scope | severity |
|-----------|------|-------|----------|
| undici | 7.24.4 → 7.28.0 | dev (jsdom/overrides) | high + medium |
| dompurify | 3.4.10 → 3.4.11 | runtime (frontend) | medium |
| pydantic-settings | 2.13.1 → 2.14.2 | runtime (backend) | medium |

### 含まれる PR
- #1095 frontend 依存のセキュリティ更新 (dompurify / undici)
- #1097 backend 依存のセキュリティ更新 (pydantic-settings)
- #1098 リリース 20260621-1 (CHANGELOG + バージョン更新)

ランタイムコードは無変更。CHANGELOG は `20260621-1` 参照。

> ⚠️ マージは GitHub Web UI で行ってください（CLI マージ禁止）。